### PR TITLE
Add core components (domain and UI) to implement chess-like games

### DIFF
--- a/app/src/main/java/com/nqueens/game/core/board/domain/Board.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/Board.kt
@@ -1,0 +1,74 @@
+package com.nqueens.game.core.board.domain
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Represents a game board for a Chess game or similar board game,
+ *
+ * The Board interface provides a reactive contract for managing the state of a chess-like
+ * board where pieces can be placed and moved. It uses StateFlow to enable reactive UI
+ * updates when the board state changes.
+ */
+interface Board {
+    /**
+     * The size of the board (number of rows and columns).
+     *
+     * For an N-Queens puzzle, this represents the dimension of the square board
+     * (N x N). The size determines how many queens need to be placed to solve
+     * the puzzle. For a standard chess board, this would be 8.
+     *
+     * @return The board dimension as a positive integer
+     */
+    val size: Int
+
+    /**
+     * Gets a reactive stream of the spot state at the specified position.
+     *
+     * This operator function allows accessing board positions using array-like syntax
+     * (e.g., `board[position]`). The returned StateFlow enables observers to react
+     * to changes in the spot state at the given position.
+     *
+     * @param position The board position to query, must be within board bounds
+     * @return A StateFlow emitting the current and future states of the spot
+     *         at the specified position
+     * @throws IndexOutOfBoundsException if the position is outside the board bounds
+     */
+    operator fun get(position: BoardPosition): StateFlow<Spot>
+
+    /**
+     * Sets the spot at the specified board position.
+     *
+     * This method updates the board state by placing or removing a piece at the
+     * given position. When called, it will trigger updates to any observers
+     * of the StateFlow for that position.
+     *
+     * @param spot The new spot state to set (either EmptySpot or PieceSpot)
+     * @param position The board position where to place the spot, must be within bounds
+     * @throws IndexOutOfBoundsException if the position is outside the board bounds
+     */
+    fun setSpot(
+        spot: Spot,
+        position: BoardPosition,
+    )
+
+    /**
+     * Retrieves all pieces currently placed on the board.
+     *
+     * This method returns a snapshot of all non-empty spots on the board,
+     * providing a map from board positions to the pieces at those positions.
+     * Empty spots are not included in the returned map.
+     *
+     * @return A map containing all positions with pieces and their corresponding
+     *         PieceSpot instances. Returns an empty map if no pieces are on the board.
+     */
+    fun getPiecesOnBoard(): Map<BoardPosition, Spot.PieceSpot>
+
+    /**
+     * Clears all pieces from the board.
+     *
+     * This method removes all pieces from the board, setting every position
+     * to EmptySpot. After calling this method, [getPiecesOnBoard] will return
+     * an empty map, and all position StateFlows will emit EmptySpot.
+     */
+    fun clear()
+}

--- a/app/src/main/java/com/nqueens/game/core/board/domain/BoardPosition.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/BoardPosition.kt
@@ -1,0 +1,47 @@
+package com.nqueens.game.core.board.domain
+
+/**
+ * Represents a position on the game board using Cartesian coordinates.
+ *
+ * BoardPosition is an immutable data class that encapsulates the x and y coordinates
+ * of a specific position on the N-Queens game board. It uses the Flyweight pattern
+ * for memory efficiency, ensuring that identical positions share the same instance.
+ *
+ * The coordinate system uses zero-based indexing where:
+ * - x represents the column (0 to board.size - 1)
+ * - y represents the row (0 to board.size - 1)
+ * - (0,0) typically represents the top-left corner of the board
+ *
+ * @property x The horizontal coordinate (column index)
+ * @property y The vertical coordinate (row index)
+ */
+@ConsistentCopyVisibility
+data class BoardPosition private constructor(
+    val x: Int,
+    val y: Int,
+) {
+    companion object {
+        private val positionCache = mutableMapOf<Pair<Int, Int>, BoardPosition>()
+
+        /**
+         * Creates or retrieves a BoardPosition instance for the given coordinates.
+         *
+         * This factory method implements the Flyweight pattern by returning cached
+         * instances when available, or creating and caching new instances when needed.
+         * This ensures that identical coordinates always return the same object instance.
+         *
+         * @param x The horizontal coordinate (column index), should be non-negative
+         * @param y The vertical coordinate (row index), should be non-negative
+         * @return A BoardPosition instance representing the specified coordinates
+         *
+         * @see BoardPosition
+         */
+        fun of(
+            x: Int,
+            y: Int,
+        ): BoardPosition =
+            positionCache.getOrPut(Pair(x, y)) {
+                BoardPosition(x, y)
+            }
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/board/domain/ChessBoard.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/ChessBoard.kt
@@ -1,2 +1,100 @@
 package com.nqueens.game.core.board.domain
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * A concrete implementation of the [Board] interface representing a chess-style game board.
+ *
+ * ChessBoard provides a reactive, mutable N×N square board where game pieces can be placed,
+ * moved, and removed. It uses StateFlow to enable reactive UI updates when the board state
+ * changes, making it ideal for real-time game applications.
+ *
+ * ## Key Features:
+ * - **Reactive State Management**: Each board position is backed by a StateFlow for real-time updates
+ * - **Flexible Size**: Supports any N×N board size (8×8 for standard chess, N×N for N-Queens, etc.)
+ * - **Piece Tracking**: Efficiently tracks all pieces on the board for quick lookup operations
+ * - **Bounds Checking**: Automatically validates position coordinates to prevent out-of-bounds access
+ * - **Memory Efficient**: Uses a 2D array structure optimized for board-based games
+ *
+ * ## Usage Example:
+ * ```kotlin
+ * // Create a standard 8x8 chess board
+ * val chessBoard = ChessBoard(8)
+ *
+ * // Place a piece
+ * val queen = Queen(PieceColor.WHITE)
+ * val position = BoardPosition.of(4, 4)
+ * chessBoard.setSpot(Spot.PieceSpot(queen), position)
+ *
+ * // Observe changes to a specific position
+ * chessBoard[position].collect { spot ->
+ *     when (spot) {
+ *         is Spot.EmptySpot -> println("Position is empty")
+ *         is Spot.PieceSpot -> println("Piece: ${spot.piece}")
+ *     }
+ * }
+ * ```
+ *
+ * @param n The size of the square board (number of rows and columns).
+ *          Must be a positive integer. Common values are 8 (standard chess)
+ *          or variable N (for N-Queens puzzle).
+ *
+ * @constructor Creates a new ChessBoard with the specified size, initially empty.
+ *              All positions start as [Spot.EmptySpot].
+ *
+ * @see Board
+ * @see Spot
+ * @see BoardPosition
+ *
+ * @since 1.0.0
+ */
+class ChessBoard(
+    private val n: Int,
+) : Board {
+    private val board: Array<Array<MutableStateFlow<Spot>>> =
+        Array(n) {
+            Array(n) { MutableStateFlow(Spot.EmptySpot) }
+        }
+    private val currentPieces = mutableMapOf<BoardPosition, Spot.PieceSpot>()
+
+    override val size: Int
+        get() = n
+
+    override fun getPiecesOnBoard(): Map<BoardPosition, Spot.PieceSpot> = currentPieces
+
+    override operator fun get(position: BoardPosition): StateFlow<Spot> {
+        require(isValidPosition(position)) { "Position $position is out of bounds" }
+        return board[position.x][position.y]
+    }
+
+    override fun setSpot(
+        spot: Spot,
+        position: BoardPosition,
+    ) {
+        require(isValidPosition(position)) { "Position $position is out of bounds" }
+        // Remove the previous piece from the spot.
+        val currentSpot = board[position.x][position.y]
+        if (currentSpot.value is Spot.PieceSpot) {
+            currentPieces.remove(position)
+        }
+
+        // Add the new spot
+        board[position.x][position.y].value = spot
+        if (spot is Spot.PieceSpot) {
+            currentPieces[position] = spot
+        }
+    }
+
+    private fun isValidPosition(position: BoardPosition): Boolean =
+        position.x in 0 until board.size && position.y in 0 until board.size
+
+    override fun clear() {
+        for (i in 0 until board.size) {
+            for (j in 0 until board.size) {
+                board[i][j].value = Spot.EmptySpot
+            }
+        }
+        currentPieces.clear()
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/board/domain/ChessBoard.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/ChessBoard.kt
@@ -1,0 +1,2 @@
+package com.nqueens.game.core.board.domain
+

--- a/app/src/main/java/com/nqueens/game/core/board/domain/Spot.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/Spot.kt
@@ -1,0 +1,11 @@
+package com.nqueens.game.core.board.domain
+
+import com.nqueens.game.core.board.domain.pieces.Piece
+
+sealed interface Spot {
+    data object EmptySpot : Spot
+
+    data class PieceSpot(
+        val piece: Piece,
+    ) : Spot
+}

--- a/app/src/main/java/com/nqueens/game/core/board/domain/games/BoardGame.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/games/BoardGame.kt
@@ -1,0 +1,50 @@
+package com.nqueens.game.core.board.domain.games
+
+import com.nqueens.game.core.board.domain.Board
+import com.nqueens.game.core.board.domain.BoardPosition
+import com.nqueens.game.core.board.domain.pieces.Piece
+import com.nqueens.game.core.board.domain.pieces.PieceColor
+import kotlinx.coroutines.flow.StateFlow
+
+abstract class BoardGame {
+    abstract val board: Board
+    abstract val currentPlayer: PieceColor
+    abstract val gameState: StateFlow<GameState>
+    abstract val numPlayers: Int
+
+    /**
+     * Initialize the game with the starting board configuration
+     */
+    abstract fun initialize()
+
+    /**
+     * Make a move by placing or moving a piece on the board
+     * @param piece The piece to place or move
+     * @param position The target position on the board
+     * @return true if the move was successful, false otherwise
+     */
+    abstract fun insertPiece(
+        piece: Piece,
+        position: BoardPosition,
+    ): Boolean
+
+    abstract fun removePiece(position: BoardPosition)
+
+    /**
+     * Check if the current game state represents a solved puzzle or a win condition
+     * @return true if the game is won, false otherwise
+     */
+    abstract fun isGameSolved(): Boolean
+
+    /**
+     * Reset the game to its initial state
+     */
+    abstract fun resetGame()
+}
+
+enum class GameState {
+    NOT_STARTED,
+    IN_PROGRESS,
+    SOLVED,
+    BLOCKED,
+}

--- a/app/src/main/java/com/nqueens/game/core/board/domain/pieces/Piece.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/pieces/Piece.kt
@@ -1,0 +1,49 @@
+package com.nqueens.game.core.board.domain.pieces
+
+import com.nqueens.game.core.board.domain.BoardPosition
+
+/**
+ * Represents a game piece that can be placed on the board.
+ *
+ * The Piece interface defines the contract for all game pieces in games like chess or N-Queens.
+ * Each piece has a color and the ability to calculate its possible moves based on
+ * the current board state and game rules.
+ *
+ * Implementations of this interface should define the specific movement patterns
+ * for different types of pieces (e.g., Queen, Bishop, Rook, etc.).
+ */
+interface Piece {
+    val pieceColor: PieceColor
+
+    /**
+     * Calculates all possible valid moves for this piece from the given position.
+     *
+     * This method determines where the piece can legally move based on its
+     * movement rules, the board boundaries, and the current positions of other
+     * pieces on the board. The implementation should consider:
+     * - The piece's specific movement pattern
+     * - Board boundaries (positions must be within 0 to boardSize-1)
+     * - Blocked paths due to other pieces
+     * - Game-specific rules (e.g., capturing, piece interactions)
+     *
+     * @param boardSize The size of the square board (N×N)
+     * @param fromPosition The current position of this piece
+     * @param currentPieces A map of all pieces currently on the board,
+     *                      used to determine blocked positions and potential captures.
+     *                      Defaults to an empty map if no other pieces are present.
+     * @return A list of valid [BoardPosition]s where this piece can move.
+     *         Returns an empty list if no moves are possible.
+     *
+     * @throws IllegalArgumentException if fromPosition is outside board boundaries
+     */
+    fun getPossibleMoves(
+        boardSize: Int,
+        fromPosition: BoardPosition,
+        currentPieces: Map<BoardPosition, Piece> = emptyMap(),
+    ): List<BoardPosition>
+}
+
+enum class PieceColor {
+    WHITE,
+    BLACK,
+}

--- a/app/src/main/java/com/nqueens/game/core/board/domain/pieces/QueenPiece.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/domain/pieces/QueenPiece.kt
@@ -1,0 +1,177 @@
+package com.nqueens.game.core.board.domain.pieces
+
+import com.nqueens.game.core.board.domain.BoardPosition
+
+class QueenPiece(
+    override val pieceColor: PieceColor,
+) : Piece {
+    override fun getPossibleMoves(
+        boardSize: Int,
+        fromPosition: BoardPosition,
+        currentPieces: Map<BoardPosition, Piece>,
+    ): List<BoardPosition> {
+        val possibleMoves = mutableListOf<BoardPosition>()
+
+        // Horizontal moves (along rows) - right
+        for (x in (fromPosition.x + 1) until boardSize) {
+            val position = BoardPosition.of(x, fromPosition.y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+        }
+
+        // Horizontal moves (along rows) - left
+        for (x in (fromPosition.x - 1) downTo 0) {
+            val position = BoardPosition.of(x, fromPosition.y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+        }
+
+        // Vertical moves (along columns) - up
+        for (y in (fromPosition.y + 1) until boardSize) {
+            val position = BoardPosition.of(fromPosition.x, y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+        }
+
+        // Vertical moves (along columns) - down
+        for (y in (fromPosition.y - 1) downTo 0) {
+            val position = BoardPosition.of(fromPosition.x, y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+        }
+
+        // Diagonal moves - up-right
+        var x = fromPosition.x + 1
+        var y = fromPosition.y + 1
+        while (x < boardSize && y < boardSize) {
+            val position = BoardPosition.of(x, y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+            x++
+            y++
+        }
+
+        // Diagonal moves - down-left
+        x = fromPosition.x - 1
+        y = fromPosition.y - 1
+        while (x >= 0 && y >= 0) {
+            val position = BoardPosition.of(x, y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+            x--
+            y--
+        }
+
+        // Diagonal moves - down-right
+        x = fromPosition.x + 1
+        y = fromPosition.y - 1
+        while (x < boardSize && y >= 0) {
+            val position = BoardPosition.of(x, y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+            x++
+            y--
+        }
+
+        // Diagonal moves - up-left
+        x = fromPosition.x - 1
+        y = fromPosition.y + 1
+        while (x >= 0 && y < boardSize) {
+            val position = BoardPosition.of(x, y)
+            val currentPiece = currentPieces[position]
+            when {
+                currentPiece == null -> {
+                    possibleMoves.add(position)
+                }
+                currentPiece.pieceColor != pieceColor -> {
+                    possibleMoves.add(position)
+                    break
+                }
+                else -> {
+                    break
+                }
+            }
+            x--
+            y++
+        }
+
+        return possibleMoves
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/board/ui/components/BoardCell.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/ui/components/BoardCell.kt
@@ -1,0 +1,95 @@
+package com.nqueens.game.core.board.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.R
+import com.nqueens.game.core.board.domain.Spot
+import com.nqueens.game.core.board.ui.state.CellState
+import com.nqueens.game.core.board.ui.state.SelectedState
+import com.nqueens.game.core.design.theme.errorDark
+import com.nqueens.game.core.icons.ChessGamesIcons
+import com.nqueens.game.core.icons.pieces.WhiteQueen
+
+@Composable
+fun RowScope.BoardCell(
+    row: Int,
+    col: Int,
+    cellState: CellState,
+    modifier: Modifier = Modifier,
+    onCellTapped: ((Int, Int) -> Unit)? = null,
+) {
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val lightColor = primaryColor.copy(alpha = 0.3f)
+    val darkColor = primaryColor.copy(alpha = 0.8f)
+
+    val isDarkSquare = (row + col) % 2 == 0
+    val cellColor =
+        when {
+            cellState.hasErrorColor -> errorDark
+            isDarkSquare -> darkColor
+            else -> lightColor
+        }
+
+    Box(
+        modifier =
+            modifier
+                .aspectRatio(1f)
+                .weight(1f)
+                .background(cellColor)
+                .border(
+                    width = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                ).clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) {
+                    onCellTapped?.invoke(row, col)
+                },
+    ) {
+        if (cellState.spot is Spot.PieceSpot) {
+            Image(
+                // NOTE(Danilo): once we implement new pieces, we need to change this icon.
+                imageVector = ChessGamesIcons.Pieces.WhiteQueen,
+                contentDescription = null,
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(8.dp),
+            )
+
+            // Add X icon overlay when selected for deletion
+            if (cellState.selected == SelectedState.TO_DELETE) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = stringResource(R.string.delete),
+                    tint = Color.Red,
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .size(24.dp)
+                            .padding(4.dp),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/board/ui/components/BoardView.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/ui/components/BoardView.kt
@@ -1,0 +1,158 @@
+package com.nqueens.game.core.board.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nqueens.game.core.board.domain.Board
+import com.nqueens.game.core.board.domain.BoardPosition
+import com.nqueens.game.core.board.domain.ChessBoard
+import com.nqueens.game.core.board.domain.Spot
+import com.nqueens.game.core.board.domain.games.BoardGame
+import com.nqueens.game.core.board.domain.games.GameState
+import com.nqueens.game.core.board.domain.pieces.Piece
+import com.nqueens.game.core.board.domain.pieces.PieceColor
+import com.nqueens.game.core.board.domain.pieces.QueenPiece
+import com.nqueens.game.core.board.ui.state.BoardUiState
+import com.nqueens.game.core.board.ui.state.CellState
+import com.nqueens.game.core.design.theme.ChessGamesTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@Composable
+fun BoardView(
+    boardState: BoardUiState,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            val size = boardState.boardSize
+            // From n-1 to 0 to create a top-down view
+            (size - 1 downTo 0).forEach { col ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    repeat(size) { row ->
+                        BoardCell(
+                            row = row,
+                            col = col,
+                            cellState =
+                                boardState
+                                    .getCellState(row, col)
+                                    .collectAsStateWithLifecycle(CellState.emptyCellState)
+                                    .value,
+                            onCellTapped = boardState::tapOnCell,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Dummy implementations for previews
+private class DummyBoardGame(
+    private val size: Int,
+) : BoardGame() {
+    override val board: Board = ChessBoard(size)
+    override val currentPlayer: PieceColor = PieceColor.WHITE
+    override val gameState: StateFlow<GameState> = MutableStateFlow(GameState.IN_PROGRESS)
+    override val numPlayers: Int = 1
+
+    override fun initialize() {}
+
+    override fun insertPiece(
+        piece: Piece,
+        position: BoardPosition,
+    ): Boolean {
+        board.setSpot(Spot.PieceSpot(piece), position)
+        return true
+    }
+
+    override fun removePiece(position: BoardPosition) {
+        board.setSpot(Spot.EmptySpot, position)
+    }
+
+    override fun isGameSolved(): Boolean = false
+
+    override fun resetGame() {
+        repeat(size) { x ->
+            repeat(size) { y ->
+                board.setSpot(Spot.EmptySpot, BoardPosition.of(x, y))
+            }
+        }
+    }
+}
+
+private class DummyBoardUiState(
+    boardGame: BoardGame,
+) : BoardUiState(boardGame) {
+    override val boardSize: Int = (boardGame as DummyBoardGame).board.size
+
+    override fun tapOnCell(
+        x: Int,
+        y: Int,
+    ) {
+        // Dummy implementation - do nothing
+    }
+
+    override fun resetGame() {
+        // Dummy implementation - do nothing
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ChessBoardPreview4x4() {
+    val boardGame = DummyBoardGame(8)
+    boardGame.insertPiece(QueenPiece(PieceColor.WHITE), BoardPosition.of(0, 3))
+    boardGame.insertPiece(QueenPiece(PieceColor.WHITE), BoardPosition.of(0, 0))
+    boardGame.insertPiece(QueenPiece(PieceColor.WHITE), BoardPosition.of(3, 2))
+    val state = DummyBoardUiState(boardGame)
+    ChessGamesTheme {
+        BoardView(
+            boardState = state,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ChessBoardPreview8x8() {
+    val boardGame = DummyBoardGame(8)
+    boardGame.insertPiece(QueenPiece(PieceColor.WHITE), BoardPosition.of(0, 0))
+    boardGame.insertPiece(QueenPiece(PieceColor.WHITE), BoardPosition.of(2, 2))
+    val state = DummyBoardUiState(boardGame)
+    ChessGamesTheme {
+        BoardView(
+            boardState = state,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ChessBoardPreview6x6() {
+    val boardGame = DummyBoardGame(6)
+    ChessGamesTheme {
+        BoardView(
+            boardState = DummyBoardUiState(boardGame),
+        )
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/board/ui/state/BoardUiState.kt
+++ b/app/src/main/java/com/nqueens/game/core/board/ui/state/BoardUiState.kt
@@ -1,0 +1,114 @@
+package com.nqueens.game.core.board.ui.state
+
+import com.nqueens.game.core.board.domain.BoardPosition
+import com.nqueens.game.core.board.domain.Spot
+import com.nqueens.game.core.board.domain.games.BoardGame
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+
+enum class SelectedState {
+    TO_MOVE,
+    TO_DELETE,
+    NOT_SELECTED,
+}
+
+data class CellState(
+    val spot: Spot,
+    val hasErrorColor: Boolean,
+    val selected: SelectedState = SelectedState.NOT_SELECTED,
+) {
+    companion object {
+        val emptyCellState = CellState(Spot.EmptySpot, false, SelectedState.NOT_SELECTED)
+    }
+}
+
+abstract class BoardUiState(
+    private val boardGame: BoardGame,
+) {
+    abstract val boardSize: Int
+
+    protected val cellErrors = mutableMapOf<BoardPosition, MutableStateFlow<Boolean>>()
+    protected val cellSelections = mutableMapOf<BoardPosition, MutableStateFlow<SelectedState>>()
+
+    val boardCells: Map<BoardPosition, Flow<CellState>> =
+        buildMap {
+            val n = boardGame.board.size
+            repeat(n) { x ->
+                repeat(n) { y ->
+                    val currentPosition = BoardPosition.of(x, y)
+
+                    // Create error flow for this position
+                    val errorFlow = MutableStateFlow<Boolean>(false)
+                    cellErrors[currentPosition] = errorFlow
+
+                    // Create selection flow for this position
+                    val selectionFlow = MutableStateFlow(SelectedState.NOT_SELECTED) // Initialize with not selected
+                    cellSelections[currentPosition] = selectionFlow
+
+                    // Combine spot changes with error state and selection state
+                    val cellState =
+                        combine(
+                            boardGame.board[currentPosition],
+                            errorFlow,
+                            selectionFlow,
+                        ) { spot, hasError, isSelected ->
+                            CellState(
+                                spot = spot,
+                                hasErrorColor = hasError,
+                                selected = isSelected,
+                            )
+                        }
+
+                    put(currentPosition, cellState)
+                }
+            }
+        }
+
+    fun selectCell(
+        position: BoardPosition,
+        state: SelectedState = SelectedState.TO_MOVE,
+    ) {
+        cellSelections[position]?.value = state
+    }
+
+    fun deselectCell(position: BoardPosition) {
+        cellSelections[position]?.value = SelectedState.NOT_SELECTED
+    }
+
+    fun clearAllSelections() {
+        cellSelections.values.forEach { selectionFlow ->
+            selectionFlow.value = SelectedState.NOT_SELECTED
+        }
+    }
+
+    fun isCellSelected(position: BoardPosition): Boolean = cellSelections[position]?.value != SelectedState.NOT_SELECTED
+
+    fun setPositionError(
+        position: BoardPosition,
+        hasError: Boolean,
+    ) {
+        cellErrors[position]?.value = hasError
+    }
+
+    fun clearAllErrors() {
+        cellErrors.values.forEach { errorFlow ->
+            errorFlow.value = false
+        }
+    }
+
+    abstract fun tapOnCell(
+        x: Int,
+        y: Int,
+    )
+
+    abstract fun resetGame()
+
+    fun getCellState(
+        x: Int,
+        y: Int,
+    ): Flow<CellState> {
+        val position = BoardPosition.of(x, y)
+        return boardCells[position]!!
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/ChessGamesIcons.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/ChessGamesIcons.kt
@@ -1,0 +1,5 @@
+package com.nqueens.game.core.icons
+
+object ChessGamesIcons {
+    object Pieces
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackBishop.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackBishop.kt
@@ -1,0 +1,173 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.BlackBishop: ImageVector
+    get() {
+        if (blackBishop != null) {
+            return blackBishop!!
+        }
+        blackBishop =
+            Builder(
+                name = "BlackBishop",
+                defaultWidth = 636.0.dp,
+                defaultHeight =
+                    636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(318.68f, 206.7f),
+                            end = Offset(318.68f, 598.14f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(479.17f, 598.14f)
+                    horizontalLineTo(158.19f)
+                    verticalLineTo(506.8f)
+                    lineTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.28f, 284.12f, 380.0f, 334.57f)
+                    curveTo(388.52f, 371.25f, 420.52f, 423.56f, 437.35f, 449.39f)
+                    curveTo(443.67f, 459.09f, 447.85f, 465.05f, 447.85f, 465.05f)
+                    verticalLineTo(485.93f)
+                    lineTo(479.17f, 506.8f)
+                    verticalLineTo(598.14f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(186.89f, 485.93f)
+                    lineTo(158.19f, 506.8f)
+                    verticalLineTo(598.14f)
+                    horizontalLineTo(479.17f)
+                    verticalLineTo(506.8f)
+                    lineTo(447.85f, 485.93f)
+                    moveTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    moveTo(186.89f, 485.93f)
+                    horizontalLineTo(447.85f)
+                    moveTo(447.85f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(447.85f, 465.05f, 443.67f, 459.09f, 437.35f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.28f, 284.12f, 380.0f, 334.57f)
+                    curveTo(388.52f, 371.25f, 420.52f, 423.56f, 437.35f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    horizontalLineTo(437.35f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(318.0f, 24.46f),
+                            end = Offset(318.0f, 247.67f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(345.17f, 87.41f)
+                    curveTo(354.72f, 80.9f, 360.81f, 71.03f, 360.81f, 59.97f)
+                    curveTo(360.81f, 40.36f, 341.64f, 24.46f, 318.0f, 24.46f)
+                    curveTo(294.36f, 24.46f, 275.19f, 40.36f, 275.19f, 59.97f)
+                    curveTo(275.19f, 71.05f, 281.3f, 80.94f, 290.88f, 87.45f)
+                    lineTo(217.1f, 146.21f)
+                    curveTo(217.1f, 146.21f, 201.81f, 160.74f, 201.81f, 174.12f)
+                    curveTo(201.81f, 187.49f, 210.98f, 214.7f, 210.98f, 214.7f)
+                    lineTo(217.1f, 247.67f)
+                    horizontalLineTo(412.79f)
+                    lineTo(421.96f, 214.7f)
+                    curveTo(421.96f, 214.7f, 434.19f, 187.49f, 434.19f, 174.12f)
+                    curveTo(434.19f, 160.74f, 421.96f, 146.21f, 421.96f, 146.21f)
+                    lineTo(345.17f, 87.41f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(210.98f, 214.7f)
+                    curveTo(210.98f, 214.7f, 201.81f, 187.49f, 201.81f, 174.12f)
+                    curveTo(201.81f, 160.74f, 217.1f, 146.21f, 217.1f, 146.21f)
+                    lineTo(290.88f, 87.45f)
+                    curveTo(281.3f, 80.94f, 275.19f, 71.05f, 275.19f, 59.97f)
+                    curveTo(275.19f, 40.36f, 294.36f, 24.46f, 318.0f, 24.46f)
+                    curveTo(341.64f, 24.46f, 360.81f, 40.36f, 360.81f, 59.97f)
+                    curveTo(360.81f, 71.03f, 354.72f, 80.9f, 345.17f, 87.41f)
+                    lineTo(421.96f, 146.21f)
+                    curveTo(421.96f, 146.21f, 434.19f, 160.74f, 434.19f, 174.12f)
+                    curveTo(434.19f, 187.49f, 421.96f, 214.7f, 421.96f, 214.7f)
+                    moveTo(210.98f, 214.7f)
+                    lineTo(217.1f, 247.67f)
+                    horizontalLineTo(412.79f)
+                    lineTo(421.96f, 214.7f)
+                    moveTo(210.98f, 214.7f)
+                    horizontalLineTo(316.47f)
+                    horizontalLineTo(421.96f)
+                }
+            }.build()
+        return blackBishop!!
+    }
+
+private var blackBishop: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.BlackBishop, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackKing.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackKing.kt
@@ -1,0 +1,195 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.BlackKing: ImageVector
+    get() {
+        if (blackKing != null) {
+            return blackKing!!
+        }
+        blackKing =
+            Builder(
+                name = "BlackKing",
+                defaultWidth = 636.0.dp,
+                defaultHeight = 765.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 765.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(320.22f, 356.3f),
+                            end = Offset(320.22f, 747.74f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(480.71f, 747.74f)
+                    horizontalLineTo(159.73f)
+                    verticalLineTo(656.4f)
+                    lineTo(188.43f, 635.53f)
+                    verticalLineTo(614.65f)
+                    curveTo(188.43f, 614.65f, 193.87f, 608.7f, 201.84f, 598.99f)
+                    curveTo(220.07f, 576.78f, 251.57f, 534.93f, 261.5f, 499.83f)
+                    curveTo(275.77f, 449.38f, 256.28f, 356.3f, 256.28f, 356.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 356.3f, 369.82f, 433.72f, 381.54f, 484.17f)
+                    curveTo(390.06f, 520.85f, 422.06f, 573.16f, 438.89f, 598.99f)
+                    curveTo(445.21f, 608.69f, 449.39f, 614.65f, 449.39f, 614.65f)
+                    verticalLineTo(635.53f)
+                    lineTo(480.71f, 656.4f)
+                    verticalLineTo(747.74f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(188.43f, 635.53f)
+                    lineTo(159.73f, 656.4f)
+                    verticalLineTo(747.74f)
+                    horizontalLineTo(480.71f)
+                    verticalLineTo(656.4f)
+                    lineTo(449.39f, 635.53f)
+                    moveTo(188.43f, 635.53f)
+                    verticalLineTo(614.65f)
+                    curveTo(188.43f, 614.65f, 193.87f, 608.7f, 201.84f, 598.99f)
+                    moveTo(188.43f, 635.53f)
+                    horizontalLineTo(449.39f)
+                    moveTo(449.39f, 635.53f)
+                    verticalLineTo(614.65f)
+                    curveTo(449.39f, 614.65f, 445.21f, 608.69f, 438.89f, 598.99f)
+                    moveTo(201.84f, 598.99f)
+                    curveTo(220.07f, 576.78f, 251.57f, 534.93f, 261.5f, 499.83f)
+                    curveTo(275.77f, 449.38f, 256.28f, 356.3f, 256.28f, 356.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 356.3f, 369.82f, 433.72f, 381.54f, 484.17f)
+                    curveTo(390.06f, 520.85f, 422.06f, 573.16f, 438.89f, 598.99f)
+                    moveTo(201.84f, 598.99f)
+                    horizontalLineTo(438.89f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(324.12f, 9.75f),
+                            end = Offset(324.12f, 372.71f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(308.6f, 104.61f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(272.78f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(306.21f)
+                    verticalLineTo(9.75f)
+                    horizontalLineTo(332.48f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(365.91f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(332.48f)
+                    verticalLineTo(104.35f)
+                    curveTo(349.03f, 108.68f, 358.74f, 122.15f, 358.74f, 138.7f)
+                    curveTo(358.74f, 150.64f, 356.54f, 158.5f, 345.8f, 166.31f)
+                    lineTo(449.48f, 267.64f)
+                    lineTo(392.17f, 317.79f)
+                    horizontalLineTo(406.5f)
+                    verticalLineTo(372.71f)
+                    horizontalLineTo(234.57f)
+                    verticalLineTo(317.79f)
+                    horizontalLineTo(251.29f)
+                    lineTo(198.75f, 267.64f)
+                    lineTo(291.88f, 164.96f)
+                    horizontalLineTo(293.52f)
+                    curveTo(283.78f, 157.09f, 282.33f, 145.86f, 282.33f, 138.7f)
+                    curveTo(282.33f, 122.72f, 293.16f, 109.26f, 308.6f, 104.61f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(392.17f, 317.79f)
+                    lineTo(449.48f, 267.64f)
+                    lineTo(345.8f, 166.31f)
+                    curveTo(356.54f, 158.5f, 358.74f, 150.64f, 358.74f, 138.7f)
+                    curveTo(358.74f, 122.15f, 349.03f, 108.68f, 332.48f, 104.35f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(365.91f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(332.48f)
+                    verticalLineTo(9.75f)
+                    horizontalLineTo(306.21f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(272.78f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(308.6f)
+                    verticalLineTo(104.61f)
+                    curveTo(293.16f, 109.26f, 282.33f, 122.72f, 282.33f, 138.7f)
+                    curveTo(282.33f, 145.86f, 283.78f, 157.09f, 293.52f, 164.96f)
+                    horizontalLineTo(291.88f)
+                    lineTo(198.75f, 267.64f)
+                    lineTo(251.29f, 317.79f)
+                    moveTo(392.17f, 317.79f)
+                    horizontalLineTo(406.5f)
+                    verticalLineTo(372.71f)
+                    horizontalLineTo(234.57f)
+                    verticalLineTo(317.79f)
+                    horizontalLineTo(251.29f)
+                    moveTo(392.17f, 317.79f)
+                    horizontalLineTo(251.29f)
+                }
+            }.build()
+        return blackKing!!
+    }
+
+private var blackKing: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.BlackKing, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackKnight.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackKnight.kt
@@ -1,0 +1,121 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.BlackKnight: ImageVector
+    get() {
+        if (blackKnight != null) {
+            return blackKnight!!
+        }
+        blackKnight =
+            Builder(
+                name = "BlackKnight",
+                defaultWidth = 636.0.dp,
+                defaultHeight =
+                    636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(317.24f, 30.58f),
+                            end = Offset(317.24f, 606.67f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(499.93f, 606.67f)
+                    horizontalLineTo(179.88f)
+                    verticalLineTo(513.32f)
+                    lineTo(209.22f, 489.32f)
+                    lineTo(227.89f, 449.31f)
+                    curveTo(227.89f, 449.31f, 221.1f, 415.35f, 231.89f, 379.97f)
+                    curveTo(247.65f, 328.28f, 307.9f, 233.28f, 307.9f, 233.28f)
+                    curveTo(307.9f, 233.28f, 287.9f, 262.61f, 243.89f, 251.95f)
+                    curveTo(199.88f, 241.28f, 155.88f, 273.28f, 155.88f, 273.28f)
+                    lineTo(134.54f, 209.27f)
+                    lineTo(209.22f, 163.93f)
+                    curveTo(209.22f, 163.93f, 208.62f, 138.51f, 227.89f, 123.93f)
+                    curveTo(247.16f, 109.34f, 307.9f, 89.25f, 307.9f, 89.25f)
+                    verticalLineTo(30.58f)
+                    curveTo(307.9f, 30.58f, 438.24f, 115.28f, 467.93f, 198.6f)
+                    curveTo(497.61f, 281.93f, 459.93f, 449.31f, 459.93f, 449.31f)
+                    lineTo(470.59f, 489.32f)
+                    lineTo(499.93f, 513.32f)
+                    verticalLineTo(606.67f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(470.59f, 489.32f)
+                    lineTo(499.93f, 513.32f)
+                    verticalLineTo(606.67f)
+                    horizontalLineTo(179.88f)
+                    verticalLineTo(513.32f)
+                    lineTo(209.22f, 489.32f)
+                    moveTo(470.59f, 489.32f)
+                    lineTo(459.93f, 449.31f)
+                    moveTo(470.59f, 489.32f)
+                    horizontalLineTo(209.22f)
+                    moveTo(459.93f, 449.31f)
+                    curveTo(459.93f, 449.31f, 497.61f, 281.93f, 467.93f, 198.6f)
+                    curveTo(438.24f, 115.28f, 307.9f, 30.58f, 307.9f, 30.58f)
+                    verticalLineTo(89.25f)
+                    curveTo(307.9f, 89.25f, 247.16f, 109.34f, 227.89f, 123.93f)
+                    curveTo(208.62f, 138.51f, 209.22f, 163.93f, 209.22f, 163.93f)
+                    lineTo(134.54f, 209.27f)
+                    lineTo(155.88f, 273.28f)
+                    curveTo(155.88f, 273.28f, 199.88f, 241.28f, 243.89f, 251.95f)
+                    curveTo(287.9f, 262.61f, 307.9f, 233.28f, 307.9f, 233.28f)
+                    curveTo(307.9f, 233.28f, 247.65f, 328.28f, 231.89f, 379.97f)
+                    curveTo(221.1f, 415.35f, 227.89f, 449.31f, 227.89f, 449.31f)
+                    moveTo(459.93f, 449.31f)
+                    horizontalLineTo(227.89f)
+                    moveTo(227.89f, 449.31f)
+                    lineTo(209.22f, 489.32f)
+                }
+            }.build()
+        return blackKnight!!
+    }
+
+private var blackKnight: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.BlackKnight, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackPawn.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackPawn.kt
@@ -1,0 +1,134 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.BlackPawn: ImageVector
+    get() {
+        if (blackPawn != null) {
+            return blackPawn!!
+        }
+        blackPawn =
+            Builder(
+                name = "BlackPawn",
+                defaultWidth = 636.0.dp,
+                defaultHeight = 636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF000000),
+                            1.0f to Color(0xFF1A1A1A),
+                            start =
+                                Offset(318.68f, 206.7f),
+                            end = Offset(318.68f, 598.14f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(479.17f, 598.14f)
+                    horizontalLineTo(158.19f)
+                    verticalLineTo(506.8f)
+                    lineTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.25f, 420.52f, 423.57f, 437.36f, 449.39f)
+                    curveTo(443.67f, 459.09f, 447.86f, 465.05f, 447.86f, 465.05f)
+                    verticalLineTo(485.93f)
+                    lineTo(479.17f, 506.8f)
+                    verticalLineTo(598.14f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(186.89f, 485.93f)
+                    lineTo(158.19f, 506.8f)
+                    verticalLineTo(598.14f)
+                    horizontalLineTo(479.17f)
+                    verticalLineTo(506.8f)
+                    lineTo(447.86f, 485.93f)
+                    moveTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    moveTo(186.89f, 485.93f)
+                    horizontalLineTo(447.86f)
+                    moveTo(447.86f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(447.86f, 465.05f, 443.67f, 459.09f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.25f, 420.52f, 423.57f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    horizontalLineTo(437.36f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF000000),
+                            1.0f to Color(0xFF1A1A1A),
+                            start =
+                                Offset(322.59f, 42.29f),
+                            end = Offset(322.59f, 235.4f),
+                        ),
+                    stroke =
+                        SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(322.59f, 138.85f)
+                    moveToRelative(-96.56f, 0.0f)
+                    arcToRelative(96.56f, 96.56f, 0.0f, true, true, 193.11f, 0.0f)
+                    arcToRelative(96.56f, 96.56f, 0.0f, true, true, -193.11f, 0.0f)
+                }
+            }.build()
+        return blackPawn!!
+    }
+
+private var blackPawn: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.BlackPawn, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackQueen.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackQueen.kt
@@ -1,0 +1,184 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.BlackQueen: ImageVector
+    get() {
+        if (blackQueen != null) {
+            return blackQueen!!
+        }
+        blackQueen =
+            Builder(
+                name = "BlackQueen",
+                defaultWidth = 636.0.dp,
+                defaultHeight =
+                    636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(320.21f, 227.3f),
+                            end = Offset(320.21f, 618.74f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(480.7f, 618.74f)
+                    horizontalLineTo(159.72f)
+                    verticalLineTo(527.41f)
+                    lineTo(188.43f, 506.53f)
+                    verticalLineTo(485.65f)
+                    curveTo(188.43f, 485.65f, 193.87f, 479.7f, 201.84f, 469.99f)
+                    curveTo(220.07f, 447.79f, 251.57f, 405.93f, 261.5f, 370.83f)
+                    curveTo(275.77f, 320.38f, 256.28f, 227.3f, 256.28f, 227.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 227.3f, 369.82f, 304.72f, 381.54f, 355.17f)
+                    curveTo(390.06f, 391.85f, 422.06f, 444.17f, 438.89f, 469.99f)
+                    curveTo(445.21f, 479.69f, 449.39f, 485.65f, 449.39f, 485.65f)
+                    verticalLineTo(506.53f)
+                    lineTo(480.7f, 527.41f)
+                    verticalLineTo(618.74f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(188.43f, 506.53f)
+                    lineTo(159.72f, 527.41f)
+                    verticalLineTo(618.74f)
+                    horizontalLineTo(480.7f)
+                    verticalLineTo(527.41f)
+                    lineTo(449.39f, 506.53f)
+                    moveTo(188.43f, 506.53f)
+                    verticalLineTo(485.65f)
+                    curveTo(188.43f, 485.65f, 193.87f, 479.7f, 201.84f, 469.99f)
+                    moveTo(188.43f, 506.53f)
+                    horizontalLineTo(449.39f)
+                    moveTo(449.39f, 506.53f)
+                    verticalLineTo(485.65f)
+                    curveTo(449.39f, 485.65f, 445.21f, 479.69f, 438.89f, 469.99f)
+                    moveTo(201.84f, 469.99f)
+                    curveTo(220.07f, 447.79f, 251.57f, 405.93f, 261.5f, 370.83f)
+                    curveTo(275.77f, 320.38f, 256.28f, 227.3f, 256.28f, 227.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 227.3f, 369.82f, 304.72f, 381.54f, 355.17f)
+                    curveTo(390.06f, 391.85f, 422.06f, 444.17f, 438.89f, 469.99f)
+                    moveTo(201.84f, 469.99f)
+                    horizontalLineTo(438.89f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(322.98f, 27.64f),
+                            end = Offset(322.98f, 287.79f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(344.02f, 102.76f)
+                    curveTo(352.02f, 95.15f, 360.15f, 81.37f, 360.15f, 69.45f)
+                    curveTo(360.15f, 46.36f, 341.43f, 27.64f, 318.34f, 27.64f)
+                    curveTo(295.25f, 27.64f, 276.53f, 46.36f, 276.53f, 69.45f)
+                    curveTo(276.53f, 83.05f, 287.89f, 95.13f, 297.94f, 102.76f)
+                    lineTo(276.53f, 132.17f)
+                    curveTo(276.53f, 132.17f, 244.93f, 128.99f, 225.43f, 132.17f)
+                    curveTo(205.93f, 135.34f, 172.01f, 157.71f, 172.01f, 157.71f)
+                    curveTo(172.01f, 157.71f, 212.28f, 174.81f, 225.43f, 190.23f)
+                    curveTo(238.58f, 205.65f, 257.95f, 236.69f, 257.95f, 236.69f)
+                    horizontalLineTo(241.69f)
+                    verticalLineTo(287.79f)
+                    horizontalLineTo(406.6f)
+                    verticalLineTo(236.69f)
+                    horizontalLineTo(392.66f)
+                    curveTo(392.66f, 236.69f, 406.99f, 205.65f, 422.86f, 190.23f)
+                    curveTo(438.73f, 174.81f, 473.96f, 157.71f, 473.96f, 157.71f)
+                    curveTo(473.96f, 157.71f, 443.27f, 135.34f, 422.86f, 132.17f)
+                    curveTo(402.45f, 128.99f, 369.44f, 132.17f, 369.44f, 132.17f)
+                    lineTo(344.02f, 102.76f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(257.95f, 236.69f)
+                    curveTo(257.95f, 236.69f, 238.58f, 205.65f, 225.43f, 190.23f)
+                    curveTo(212.28f, 174.81f, 172.01f, 157.71f, 172.01f, 157.71f)
+                    curveTo(172.01f, 157.71f, 205.93f, 135.34f, 225.43f, 132.17f)
+                    curveTo(244.93f, 128.99f, 276.53f, 132.17f, 276.53f, 132.17f)
+                    lineTo(297.94f, 102.76f)
+                    curveTo(287.89f, 95.13f, 276.53f, 83.05f, 276.53f, 69.45f)
+                    curveTo(276.53f, 46.36f, 295.25f, 27.64f, 318.34f, 27.64f)
+                    curveTo(341.43f, 27.64f, 360.15f, 46.36f, 360.15f, 69.45f)
+                    curveTo(360.15f, 81.37f, 352.02f, 95.15f, 344.02f, 102.76f)
+                    lineTo(369.44f, 132.17f)
+                    curveTo(369.44f, 132.17f, 402.45f, 128.99f, 422.86f, 132.17f)
+                    curveTo(443.27f, 135.34f, 473.96f, 157.71f, 473.96f, 157.71f)
+                    curveTo(473.96f, 157.71f, 438.73f, 174.81f, 422.86f, 190.23f)
+                    curveTo(406.99f, 205.65f, 392.66f, 236.69f, 392.66f, 236.69f)
+                    moveTo(257.95f, 236.69f)
+                    horizontalLineTo(241.69f)
+                    verticalLineTo(287.79f)
+                    horizontalLineTo(406.6f)
+                    verticalLineTo(236.69f)
+                    horizontalLineTo(392.66f)
+                    moveTo(257.95f, 236.69f)
+                    horizontalLineTo(392.66f)
+                }
+            }.build()
+        return blackQueen!!
+    }
+
+private var blackQueen: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.BlackQueen, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackRook.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/BlackRook.kt
@@ -1,0 +1,177 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.BlackRook: ImageVector
+    get() {
+        if (blackRook != null) {
+            return blackRook!!
+        }
+        blackRook =
+            Builder(
+                name = "BlackRook",
+                defaultWidth = 636.0.dp,
+                defaultHeight = 636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(318.68f, 206.7f),
+                            end = Offset(318.68f, 598.14f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(479.17f, 598.14f)
+                    horizontalLineTo(158.19f)
+                    verticalLineTo(506.8f)
+                    lineTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.04f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.25f, 420.52f, 423.57f, 437.36f, 449.39f)
+                    curveTo(443.67f, 459.09f, 447.86f, 465.05f, 447.86f, 465.05f)
+                    verticalLineTo(485.93f)
+                    lineTo(479.17f, 506.8f)
+                    verticalLineTo(598.14f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(186.89f, 485.93f)
+                    lineTo(158.19f, 506.8f)
+                    verticalLineTo(598.14f)
+                    horizontalLineTo(479.17f)
+                    verticalLineTo(506.8f)
+                    lineTo(447.86f, 485.93f)
+                    moveTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    moveTo(186.89f, 485.93f)
+                    horizontalLineTo(447.86f)
+                    moveTo(447.86f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(447.86f, 465.05f, 443.67f, 459.09f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.04f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.25f, 420.52f, 423.57f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    horizontalLineTo(437.36f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFF1A1A1A),
+                            1.0f to Color(0xFF0D0D0D),
+                            start =
+                                Offset(319.22f, 30.72f),
+                            end = Offset(319.22f, 236.51f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(159.72f, 30.72f)
+                    horizontalLineTo(248.9f)
+                    verticalLineTo(123.33f)
+                    horizontalLineTo(279.77f)
+                    verticalLineTo(30.72f)
+                    horizontalLineTo(362.09f)
+                    verticalLineTo(123.33f)
+                    horizontalLineTo(392.96f)
+                    verticalLineTo(30.72f)
+                    horizontalLineTo(478.71f)
+                    verticalLineTo(185.07f)
+                    verticalLineTo(205.65f)
+                    lineTo(451.27f, 236.51f)
+                    horizontalLineTo(197.45f)
+                    lineTo(159.72f, 205.65f)
+                    verticalLineTo(185.07f)
+                    verticalLineTo(30.72f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFFffffff)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(159.72f, 185.07f)
+                    verticalLineTo(205.65f)
+                    lineTo(197.45f, 236.51f)
+                    horizontalLineTo(451.27f)
+                    lineTo(478.71f, 205.65f)
+                    verticalLineTo(185.07f)
+                    moveTo(159.72f, 185.07f)
+                    verticalLineTo(30.72f)
+                    horizontalLineTo(248.9f)
+                    verticalLineTo(123.33f)
+                    horizontalLineTo(279.77f)
+                    verticalLineTo(30.72f)
+                    horizontalLineTo(362.09f)
+                    verticalLineTo(123.33f)
+                    horizontalLineTo(392.96f)
+                    verticalLineTo(30.72f)
+                    horizontalLineTo(478.71f)
+                    verticalLineTo(185.07f)
+                    moveTo(159.72f, 185.07f)
+                    horizontalLineTo(478.71f)
+                }
+            }.build()
+        return blackRook!!
+    }
+
+private var blackRook: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.BlackRook, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteBishop.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteBishop.kt
@@ -1,0 +1,173 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.WhiteBishop: ImageVector
+    get() {
+        if (whiteBishop != null) {
+            return whiteBishop!!
+        }
+        whiteBishop =
+            Builder(
+                name = "WhiteBishop",
+                defaultWidth = 636.0.dp,
+                defaultHeight =
+                    636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(318.68f, 206.7f),
+                            end = Offset(318.68f, 598.14f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(479.17f, 598.14f)
+                    horizontalLineTo(158.19f)
+                    verticalLineTo(506.8f)
+                    lineTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.28f, 284.12f, 380.0f, 334.57f)
+                    curveTo(388.52f, 371.25f, 420.52f, 423.56f, 437.35f, 449.39f)
+                    curveTo(443.67f, 459.09f, 447.85f, 465.05f, 447.85f, 465.05f)
+                    verticalLineTo(485.93f)
+                    lineTo(479.17f, 506.8f)
+                    verticalLineTo(598.14f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(186.89f, 485.93f)
+                    lineTo(158.19f, 506.8f)
+                    verticalLineTo(598.14f)
+                    horizontalLineTo(479.17f)
+                    verticalLineTo(506.8f)
+                    lineTo(447.85f, 485.93f)
+                    moveTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    moveTo(186.89f, 485.93f)
+                    horizontalLineTo(447.85f)
+                    moveTo(447.85f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(447.85f, 465.05f, 443.67f, 459.09f, 437.35f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.28f, 284.12f, 380.0f, 334.57f)
+                    curveTo(388.52f, 371.25f, 420.52f, 423.56f, 437.35f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    horizontalLineTo(437.35f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(318.0f, 24.46f),
+                            end = Offset(318.0f, 247.67f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(345.17f, 87.41f)
+                    curveTo(354.72f, 80.9f, 360.81f, 71.03f, 360.81f, 59.97f)
+                    curveTo(360.81f, 40.36f, 341.64f, 24.46f, 318.0f, 24.46f)
+                    curveTo(294.36f, 24.46f, 275.19f, 40.36f, 275.19f, 59.97f)
+                    curveTo(275.19f, 71.05f, 281.3f, 80.94f, 290.88f, 87.45f)
+                    lineTo(217.1f, 146.21f)
+                    curveTo(217.1f, 146.21f, 201.81f, 160.74f, 201.81f, 174.12f)
+                    curveTo(201.81f, 187.49f, 210.98f, 214.7f, 210.98f, 214.7f)
+                    lineTo(217.1f, 247.67f)
+                    horizontalLineTo(412.79f)
+                    lineTo(421.96f, 214.7f)
+                    curveTo(421.96f, 214.7f, 434.19f, 187.49f, 434.19f, 174.12f)
+                    curveTo(434.19f, 160.74f, 421.96f, 146.21f, 421.96f, 146.21f)
+                    lineTo(345.17f, 87.41f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(210.98f, 214.7f)
+                    curveTo(210.98f, 214.7f, 201.81f, 187.49f, 201.81f, 174.12f)
+                    curveTo(201.81f, 160.74f, 217.1f, 146.21f, 217.1f, 146.21f)
+                    lineTo(290.88f, 87.45f)
+                    curveTo(281.3f, 80.94f, 275.19f, 71.05f, 275.19f, 59.97f)
+                    curveTo(275.19f, 40.36f, 294.36f, 24.46f, 318.0f, 24.46f)
+                    curveTo(341.64f, 24.46f, 360.81f, 40.36f, 360.81f, 59.97f)
+                    curveTo(360.81f, 71.03f, 354.72f, 80.9f, 345.17f, 87.41f)
+                    lineTo(421.96f, 146.21f)
+                    curveTo(421.96f, 146.21f, 434.19f, 160.74f, 434.19f, 174.12f)
+                    curveTo(434.19f, 187.49f, 421.96f, 214.7f, 421.96f, 214.7f)
+                    moveTo(210.98f, 214.7f)
+                    lineTo(217.1f, 247.67f)
+                    horizontalLineTo(412.79f)
+                    lineTo(421.96f, 214.7f)
+                    moveTo(210.98f, 214.7f)
+                    horizontalLineTo(316.47f)
+                    horizontalLineTo(421.96f)
+                }
+            }.build()
+        return whiteBishop!!
+    }
+
+private var whiteBishop: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.WhiteBishop, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteKIng.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteKIng.kt
@@ -1,0 +1,195 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.WhiteKing: ImageVector
+    get() {
+        if (whiteKing != null) {
+            return whiteKing!!
+        }
+        whiteKing =
+            Builder(
+                name = "WhiteKing",
+                defaultWidth = 636.0.dp,
+                defaultHeight = 765.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 765.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(320.22f, 356.3f),
+                            end = Offset(320.22f, 747.74f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(480.7f, 747.74f)
+                    horizontalLineTo(159.72f)
+                    verticalLineTo(656.4f)
+                    lineTo(188.43f, 635.53f)
+                    verticalLineTo(614.65f)
+                    curveTo(188.43f, 614.65f, 193.87f, 608.7f, 201.84f, 598.99f)
+                    curveTo(220.07f, 576.78f, 251.57f, 534.93f, 261.5f, 499.83f)
+                    curveTo(275.77f, 449.38f, 256.28f, 356.3f, 256.28f, 356.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 356.3f, 369.82f, 433.72f, 381.54f, 484.17f)
+                    curveTo(390.06f, 520.85f, 422.06f, 573.17f, 438.89f, 598.99f)
+                    curveTo(445.21f, 608.69f, 449.39f, 614.65f, 449.39f, 614.65f)
+                    verticalLineTo(635.53f)
+                    lineTo(480.7f, 656.4f)
+                    verticalLineTo(747.74f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(188.43f, 635.53f)
+                    lineTo(159.72f, 656.4f)
+                    verticalLineTo(747.74f)
+                    horizontalLineTo(480.7f)
+                    verticalLineTo(656.4f)
+                    lineTo(449.39f, 635.53f)
+                    moveTo(188.43f, 635.53f)
+                    verticalLineTo(614.65f)
+                    curveTo(188.43f, 614.65f, 193.87f, 608.7f, 201.84f, 598.99f)
+                    moveTo(188.43f, 635.53f)
+                    horizontalLineTo(449.39f)
+                    moveTo(449.39f, 635.53f)
+                    verticalLineTo(614.65f)
+                    curveTo(449.39f, 614.65f, 445.21f, 608.69f, 438.89f, 598.99f)
+                    moveTo(201.84f, 598.99f)
+                    curveTo(220.07f, 576.78f, 251.57f, 534.93f, 261.5f, 499.83f)
+                    curveTo(275.77f, 449.38f, 256.28f, 356.3f, 256.28f, 356.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 356.3f, 369.82f, 433.72f, 381.54f, 484.17f)
+                    curveTo(390.06f, 520.85f, 422.06f, 573.17f, 438.89f, 598.99f)
+                    moveTo(201.84f, 598.99f)
+                    horizontalLineTo(438.89f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(324.12f, 9.75f),
+                            end = Offset(324.12f, 372.71f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(308.6f, 104.61f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(272.78f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(306.21f)
+                    verticalLineTo(9.75f)
+                    horizontalLineTo(332.47f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(365.9f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(332.47f)
+                    verticalLineTo(104.35f)
+                    curveTo(349.03f, 108.68f, 358.74f, 122.15f, 358.74f, 138.7f)
+                    curveTo(358.74f, 150.64f, 356.54f, 158.5f, 345.79f, 166.31f)
+                    lineTo(449.48f, 267.64f)
+                    lineTo(392.17f, 317.79f)
+                    horizontalLineTo(406.5f)
+                    verticalLineTo(372.71f)
+                    horizontalLineTo(234.57f)
+                    verticalLineTo(317.79f)
+                    horizontalLineTo(251.29f)
+                    lineTo(198.75f, 267.64f)
+                    lineTo(291.88f, 164.96f)
+                    horizontalLineTo(293.52f)
+                    curveTo(283.78f, 157.09f, 282.33f, 145.86f, 282.33f, 138.7f)
+                    curveTo(282.33f, 122.72f, 293.16f, 109.26f, 308.6f, 104.61f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(392.17f, 317.79f)
+                    lineTo(449.48f, 267.64f)
+                    lineTo(345.79f, 166.31f)
+                    curveTo(356.54f, 158.5f, 358.74f, 150.64f, 358.74f, 138.7f)
+                    curveTo(358.74f, 122.15f, 349.03f, 108.68f, 332.47f, 104.35f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(365.9f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(332.47f)
+                    verticalLineTo(9.75f)
+                    horizontalLineTo(306.21f)
+                    verticalLineTo(45.57f)
+                    horizontalLineTo(272.78f)
+                    verticalLineTo(69.45f)
+                    horizontalLineTo(308.6f)
+                    verticalLineTo(104.61f)
+                    curveTo(293.16f, 109.26f, 282.33f, 122.72f, 282.33f, 138.7f)
+                    curveTo(282.33f, 145.86f, 283.78f, 157.09f, 293.52f, 164.96f)
+                    horizontalLineTo(291.88f)
+                    lineTo(198.75f, 267.64f)
+                    lineTo(251.29f, 317.79f)
+                    moveTo(392.17f, 317.79f)
+                    horizontalLineTo(406.5f)
+                    verticalLineTo(372.71f)
+                    horizontalLineTo(234.57f)
+                    verticalLineTo(317.79f)
+                    horizontalLineTo(251.29f)
+                    moveTo(392.17f, 317.79f)
+                    horizontalLineTo(251.29f)
+                }
+            }.build()
+        return whiteKing!!
+    }
+
+private var whiteKing: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.WhiteKing, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteKnight.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteKnight.kt
@@ -1,0 +1,121 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.WhiteKnight: ImageVector
+    get() {
+        if (whiteKnight != null) {
+            return whiteKnight!!
+        }
+        whiteKnight =
+            Builder(
+                name = "WhiteKnight",
+                defaultWidth = 636.0.dp,
+                defaultHeight =
+                    636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(317.24f, 30.58f),
+                            end = Offset(317.24f, 606.67f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(499.93f, 606.67f)
+                    horizontalLineTo(179.88f)
+                    verticalLineTo(513.32f)
+                    lineTo(209.22f, 489.32f)
+                    lineTo(227.89f, 449.31f)
+                    curveTo(227.89f, 449.31f, 221.1f, 415.35f, 231.89f, 379.97f)
+                    curveTo(247.65f, 328.28f, 307.9f, 233.28f, 307.9f, 233.28f)
+                    curveTo(307.9f, 233.28f, 287.9f, 262.62f, 243.89f, 251.95f)
+                    curveTo(199.88f, 241.28f, 155.88f, 273.28f, 155.88f, 273.28f)
+                    lineTo(134.54f, 209.27f)
+                    lineTo(209.22f, 163.93f)
+                    curveTo(209.22f, 163.93f, 208.62f, 138.51f, 227.89f, 123.93f)
+                    curveTo(247.16f, 109.34f, 307.9f, 89.25f, 307.9f, 89.25f)
+                    verticalLineTo(30.58f)
+                    curveTo(307.9f, 30.58f, 438.24f, 115.28f, 467.93f, 198.6f)
+                    curveTo(497.61f, 281.93f, 459.93f, 449.31f, 459.93f, 449.31f)
+                    lineTo(470.59f, 489.32f)
+                    lineTo(499.93f, 513.32f)
+                    verticalLineTo(606.67f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(470.59f, 489.32f)
+                    lineTo(499.93f, 513.32f)
+                    verticalLineTo(606.67f)
+                    horizontalLineTo(179.88f)
+                    verticalLineTo(513.32f)
+                    lineTo(209.22f, 489.32f)
+                    moveTo(470.59f, 489.32f)
+                    lineTo(459.93f, 449.31f)
+                    moveTo(470.59f, 489.32f)
+                    horizontalLineTo(209.22f)
+                    moveTo(459.93f, 449.31f)
+                    curveTo(459.93f, 449.31f, 497.61f, 281.93f, 467.93f, 198.6f)
+                    curveTo(438.24f, 115.28f, 307.9f, 30.58f, 307.9f, 30.58f)
+                    verticalLineTo(89.25f)
+                    curveTo(307.9f, 89.25f, 247.16f, 109.34f, 227.89f, 123.93f)
+                    curveTo(208.62f, 138.51f, 209.22f, 163.93f, 209.22f, 163.93f)
+                    lineTo(134.54f, 209.27f)
+                    lineTo(155.88f, 273.28f)
+                    curveTo(155.88f, 273.28f, 199.88f, 241.28f, 243.89f, 251.95f)
+                    curveTo(287.9f, 262.62f, 307.9f, 233.28f, 307.9f, 233.28f)
+                    curveTo(307.9f, 233.28f, 247.65f, 328.28f, 231.89f, 379.97f)
+                    curveTo(221.1f, 415.35f, 227.89f, 449.31f, 227.89f, 449.31f)
+                    moveTo(459.93f, 449.31f)
+                    horizontalLineTo(227.89f)
+                    moveTo(227.89f, 449.31f)
+                    lineTo(209.22f, 489.32f)
+                }
+            }.build()
+        return whiteKnight!!
+    }
+
+private var whiteKnight: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.WhiteKnight, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/WhitePawn.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/WhitePawn.kt
@@ -1,0 +1,134 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.WhitePawn: ImageVector
+    get() {
+        if (whitePawn != null) {
+            return whitePawn!!
+        }
+        whitePawn =
+            Builder(
+                name = "WhitePawn",
+                defaultWidth = 636.0.dp,
+                defaultHeight = 636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFFFFFFF),
+                            1.0f to Color(0xFFE5E5E5),
+                            start =
+                                Offset(318.68f, 206.7f),
+                            end = Offset(318.68f, 598.14f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(479.17f, 598.14f)
+                    horizontalLineTo(158.19f)
+                    verticalLineTo(506.8f)
+                    lineTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.25f, 420.52f, 423.57f, 437.36f, 449.39f)
+                    curveTo(443.67f, 459.09f, 447.86f, 465.05f, 447.86f, 465.05f)
+                    verticalLineTo(485.93f)
+                    lineTo(479.17f, 506.8f)
+                    verticalLineTo(598.14f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(186.89f, 485.93f)
+                    lineTo(158.19f, 506.8f)
+                    verticalLineTo(598.14f)
+                    horizontalLineTo(479.17f)
+                    verticalLineTo(506.8f)
+                    lineTo(447.86f, 485.93f)
+                    moveTo(186.89f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    moveTo(186.89f, 485.93f)
+                    horizontalLineTo(447.86f)
+                    moveTo(447.86f, 485.93f)
+                    verticalLineTo(465.05f)
+                    curveTo(447.86f, 465.05f, 443.67f, 459.09f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.03f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.25f, 420.52f, 423.57f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    horizontalLineTo(437.36f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFFFFFFF),
+                            1.0f to Color(0xFFE5E5E5),
+                            start =
+                                Offset(322.59f, 42.29f),
+                            end = Offset(322.59f, 235.4f),
+                        ),
+                    stroke =
+                        SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(322.59f, 138.85f)
+                    moveToRelative(-96.56f, 0.0f)
+                    arcToRelative(96.56f, 96.56f, 0.0f, true, true, 193.11f, 0.0f)
+                    arcToRelative(96.56f, 96.56f, 0.0f, true, true, -193.11f, 0.0f)
+                }
+            }.build()
+        return whitePawn!!
+    }
+
+private var whitePawn: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.WhitePawn, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteQueen.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteQueen.kt
@@ -1,0 +1,184 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.WhiteQueen: ImageVector
+    get() {
+        if (whiteQueen != null) {
+            return whiteQueen!!
+        }
+        whiteQueen =
+            Builder(
+                name = "WhiteQueen",
+                defaultWidth = 636.0.dp,
+                defaultHeight =
+                    636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(320.21f, 227.3f),
+                            end = Offset(320.21f, 618.74f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(480.71f, 618.74f)
+                    horizontalLineTo(159.72f)
+                    verticalLineTo(527.4f)
+                    lineTo(188.43f, 506.53f)
+                    verticalLineTo(485.65f)
+                    curveTo(188.43f, 485.65f, 193.87f, 479.7f, 201.84f, 469.99f)
+                    curveTo(220.07f, 447.79f, 251.57f, 405.93f, 261.5f, 370.83f)
+                    curveTo(275.77f, 320.38f, 256.28f, 227.3f, 256.28f, 227.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 227.3f, 369.82f, 304.72f, 381.54f, 355.17f)
+                    curveTo(390.06f, 391.85f, 422.06f, 444.17f, 438.89f, 469.99f)
+                    curveTo(445.21f, 479.69f, 449.39f, 485.65f, 449.39f, 485.65f)
+                    verticalLineTo(506.53f)
+                    lineTo(480.71f, 527.4f)
+                    verticalLineTo(618.74f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(188.43f, 506.53f)
+                    lineTo(159.72f, 527.4f)
+                    verticalLineTo(618.74f)
+                    horizontalLineTo(480.71f)
+                    verticalLineTo(527.4f)
+                    lineTo(449.39f, 506.53f)
+                    moveTo(188.43f, 506.53f)
+                    verticalLineTo(485.65f)
+                    curveTo(188.43f, 485.65f, 193.87f, 479.7f, 201.84f, 469.99f)
+                    moveTo(188.43f, 506.53f)
+                    horizontalLineTo(449.39f)
+                    moveTo(449.39f, 506.53f)
+                    verticalLineTo(485.65f)
+                    curveTo(449.39f, 485.65f, 445.21f, 479.69f, 438.89f, 469.99f)
+                    moveTo(201.84f, 469.99f)
+                    curveTo(220.07f, 447.79f, 251.57f, 405.93f, 261.5f, 370.83f)
+                    curveTo(275.77f, 320.38f, 256.28f, 227.3f, 256.28f, 227.3f)
+                    horizontalLineTo(391.98f)
+                    curveTo(391.98f, 227.3f, 369.82f, 304.72f, 381.54f, 355.17f)
+                    curveTo(390.06f, 391.85f, 422.06f, 444.17f, 438.89f, 469.99f)
+                    moveTo(201.84f, 469.99f)
+                    horizontalLineTo(438.89f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(322.98f, 27.64f),
+                            end = Offset(322.98f, 287.79f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(344.02f, 102.76f)
+                    curveTo(352.02f, 95.15f, 360.15f, 81.37f, 360.15f, 69.45f)
+                    curveTo(360.15f, 46.36f, 341.43f, 27.64f, 318.34f, 27.64f)
+                    curveTo(295.25f, 27.64f, 276.53f, 46.36f, 276.53f, 69.45f)
+                    curveTo(276.53f, 83.05f, 287.89f, 95.13f, 297.95f, 102.76f)
+                    lineTo(276.53f, 132.16f)
+                    curveTo(276.53f, 132.16f, 244.93f, 128.99f, 225.43f, 132.16f)
+                    curveTo(205.93f, 135.34f, 172.01f, 157.71f, 172.01f, 157.71f)
+                    curveTo(172.01f, 157.71f, 212.28f, 174.81f, 225.43f, 190.23f)
+                    curveTo(238.59f, 205.65f, 257.95f, 236.69f, 257.95f, 236.69f)
+                    horizontalLineTo(241.69f)
+                    verticalLineTo(287.79f)
+                    horizontalLineTo(406.6f)
+                    verticalLineTo(236.69f)
+                    horizontalLineTo(392.67f)
+                    curveTo(392.67f, 236.69f, 406.99f, 205.65f, 422.86f, 190.23f)
+                    curveTo(438.73f, 174.81f, 473.96f, 157.71f, 473.96f, 157.71f)
+                    curveTo(473.96f, 157.71f, 443.27f, 135.34f, 422.86f, 132.16f)
+                    curveTo(402.45f, 128.99f, 369.44f, 132.16f, 369.44f, 132.16f)
+                    lineTo(344.02f, 102.76f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(257.95f, 236.69f)
+                    curveTo(257.95f, 236.69f, 238.59f, 205.65f, 225.43f, 190.23f)
+                    curveTo(212.28f, 174.81f, 172.01f, 157.71f, 172.01f, 157.71f)
+                    curveTo(172.01f, 157.71f, 205.93f, 135.34f, 225.43f, 132.16f)
+                    curveTo(244.93f, 128.99f, 276.53f, 132.16f, 276.53f, 132.16f)
+                    lineTo(297.95f, 102.76f)
+                    curveTo(287.89f, 95.13f, 276.53f, 83.05f, 276.53f, 69.45f)
+                    curveTo(276.53f, 46.36f, 295.25f, 27.64f, 318.34f, 27.64f)
+                    curveTo(341.43f, 27.64f, 360.15f, 46.36f, 360.15f, 69.45f)
+                    curveTo(360.15f, 81.37f, 352.02f, 95.15f, 344.02f, 102.76f)
+                    lineTo(369.44f, 132.16f)
+                    curveTo(369.44f, 132.16f, 402.45f, 128.99f, 422.86f, 132.16f)
+                    curveTo(443.27f, 135.34f, 473.96f, 157.71f, 473.96f, 157.71f)
+                    curveTo(473.96f, 157.71f, 438.73f, 174.81f, 422.86f, 190.23f)
+                    curveTo(406.99f, 205.65f, 392.67f, 236.69f, 392.67f, 236.69f)
+                    moveTo(257.95f, 236.69f)
+                    horizontalLineTo(241.69f)
+                    verticalLineTo(287.79f)
+                    horizontalLineTo(406.6f)
+                    verticalLineTo(236.69f)
+                    horizontalLineTo(392.67f)
+                    moveTo(257.95f, 236.69f)
+                    horizontalLineTo(392.67f)
+                }
+            }.build()
+        return whiteQueen!!
+    }
+
+private var whiteQueen: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.WhiteQueen, contentDescription = "")
+    }
+}

--- a/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteRook.kt
+++ b/app/src/main/java/com/nqueens/game/core/icons/pieces/WhiteRook.kt
@@ -1,0 +1,177 @@
+package com.nqueens.game.core.icons.pieces
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush.Companion.linearGradient
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap.Companion.Butt
+import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.nqueens.game.core.icons.ChessGamesIcons
+
+public val ChessGamesIcons.Pieces.WhiteRook: ImageVector
+    get() {
+        if (whiteRook != null) {
+            return whiteRook!!
+        }
+        whiteRook =
+            Builder(
+                name = "WhiteRook",
+                defaultWidth = 636.0.dp,
+                defaultHeight = 636.0.dp,
+                viewportWidth = 636.0f,
+                viewportHeight = 636.0f,
+            ).apply {
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(318.68f, 206.7f),
+                            end = Offset(318.68f, 598.14f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(479.17f, 598.14f)
+                    horizontalLineTo(158.19f)
+                    verticalLineTo(506.8f)
+                    lineTo(186.89f, 485.92f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.04f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.24f, 420.52f, 423.56f, 437.36f, 449.39f)
+                    curveTo(443.67f, 459.09f, 447.86f, 465.05f, 447.86f, 465.05f)
+                    verticalLineTo(485.92f)
+                    lineTo(479.17f, 506.8f)
+                    verticalLineTo(598.14f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(186.89f, 485.92f)
+                    lineTo(158.19f, 506.8f)
+                    verticalLineTo(598.14f)
+                    horizontalLineTo(479.17f)
+                    verticalLineTo(506.8f)
+                    lineTo(447.86f, 485.92f)
+                    moveTo(186.89f, 485.92f)
+                    verticalLineTo(465.05f)
+                    curveTo(186.89f, 465.05f, 192.33f, 459.1f, 200.3f, 449.39f)
+                    moveTo(186.89f, 485.92f)
+                    horizontalLineTo(447.86f)
+                    moveTo(447.86f, 485.92f)
+                    verticalLineTo(465.05f)
+                    curveTo(447.86f, 465.05f, 443.67f, 459.09f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    curveTo(218.54f, 427.18f, 250.04f, 385.33f, 259.96f, 350.23f)
+                    curveTo(274.23f, 299.78f, 254.74f, 206.7f, 254.74f, 206.7f)
+                    horizontalLineTo(390.44f)
+                    curveTo(390.44f, 206.7f, 368.29f, 284.12f, 380.01f, 334.57f)
+                    curveTo(388.53f, 371.24f, 420.52f, 423.56f, 437.36f, 449.39f)
+                    moveTo(200.3f, 449.39f)
+                    horizontalLineTo(437.36f)
+                }
+                path(
+                    fill =
+                        linearGradient(
+                            0.0f to Color(0xFFF0F0F0),
+                            1.0f to Color(0xFFFFFFFF),
+                            start =
+                                Offset(319.22f, 30.71f),
+                            end = Offset(319.22f, 236.51f),
+                        ),
+                    stroke = null,
+                    strokeLineWidth = 0.0f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(159.72f, 30.71f)
+                    horizontalLineTo(248.9f)
+                    verticalLineTo(123.32f)
+                    horizontalLineTo(279.77f)
+                    verticalLineTo(30.71f)
+                    horizontalLineTo(362.09f)
+                    verticalLineTo(123.32f)
+                    horizontalLineTo(392.96f)
+                    verticalLineTo(30.71f)
+                    horizontalLineTo(478.71f)
+                    verticalLineTo(185.06f)
+                    verticalLineTo(205.64f)
+                    lineTo(451.27f, 236.51f)
+                    horizontalLineTo(197.45f)
+                    lineTo(159.72f, 205.64f)
+                    verticalLineTo(185.06f)
+                    verticalLineTo(30.71f)
+                    close()
+                }
+                path(
+                    fill = SolidColor(Color(0x00000000)),
+                    stroke = SolidColor(Color(0xFF000000)),
+                    strokeLineWidth = 18.4296f,
+                    strokeLineCap = Butt,
+                    strokeLineJoin = Miter,
+                    strokeLineMiter = 4.0f,
+                    pathFillType = NonZero,
+                ) {
+                    moveTo(159.72f, 185.06f)
+                    verticalLineTo(205.64f)
+                    lineTo(197.45f, 236.51f)
+                    horizontalLineTo(451.27f)
+                    lineTo(478.71f, 205.64f)
+                    verticalLineTo(185.06f)
+                    moveTo(159.72f, 185.06f)
+                    verticalLineTo(30.71f)
+                    horizontalLineTo(248.9f)
+                    verticalLineTo(123.32f)
+                    horizontalLineTo(279.77f)
+                    verticalLineTo(30.71f)
+                    horizontalLineTo(362.09f)
+                    verticalLineTo(123.32f)
+                    horizontalLineTo(392.96f)
+                    verticalLineTo(30.71f)
+                    horizontalLineTo(478.71f)
+                    verticalLineTo(185.06f)
+                    moveTo(159.72f, 185.06f)
+                    horizontalLineTo(478.71f)
+                }
+            }.build()
+        return whiteRook!!
+    }
+
+private var whiteRook: ImageVector? = null
+
+@Preview
+@Composable
+private fun Preview() {
+    Box(modifier = Modifier.padding(12.dp)) {
+        Image(imageVector = ChessGamesIcons.Pieces.WhiteRook, contentDescription = "")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,6 @@
     <string name="queens_range_error">Number of queens must be between %1$d and %2$d</string>
     <string name="start_game">Start Game</string>
     <string name="navigate_back">Navigate back</string>
+
+    <string name="delete">Delete</string>
 </resources>

--- a/app/src/test/java/com/nqueens/game/BaseUnitTest.kt
+++ b/app/src/test/java/com/nqueens/game/BaseUnitTest.kt
@@ -1,0 +1,13 @@
+package com.nqueens.game
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+abstract class BaseUnitTest {
+    @Rule
+    @JvmField
+    val rule = InstantTaskExecutorRule()
+}

--- a/app/src/test/java/com/nqueens/game/core/board/domain/ChessBoardTest.kt
+++ b/app/src/test/java/com/nqueens/game/core/board/domain/ChessBoardTest.kt
@@ -1,0 +1,350 @@
+package com.nqueens.game.core.board.domain
+
+import com.nqueens.game.core.board.domain.pieces.Piece
+import com.nqueens.game.core.board.domain.pieces.PieceColor
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+/**
+ * Comprehensive test suite for [ChessBoard] class.
+ *
+ * Tests cover all public methods, edge cases, boundary conditions,
+ * and reactive state management using StateFlow.
+ */
+class ChessBoardTest {
+    private lateinit var chessBoard: ChessBoard
+    private lateinit var mockPiece: Piece
+
+    @Before
+    fun setUp() {
+        chessBoard = ChessBoard(8) // Standard 8x8 chess board
+        mockPiece =
+            mock<Piece> {
+                on { pieceColor }.thenReturn(PieceColor.WHITE)
+            }
+    }
+
+    // Initialization Tests
+
+    @Test
+    fun `given new chessboard, when checking size, then returns correct board size`() {
+        assertThat(chessBoard.size).isEqualTo(8)
+    }
+
+    @Test
+    fun `given new chessboard, when checking all positions, then all positions are empty`() =
+        runTest {
+            for (x in 0 until chessBoard.size) {
+                for (y in 0 until chessBoard.size) {
+                    val position = BoardPosition.of(x, y)
+                    val spot = chessBoard[position].first()
+                    assertThat(spot).isEqualTo(Spot.EmptySpot)
+                }
+            }
+        }
+
+    @Test
+    fun `given new chessboard, when checking pieces on board, then no pieces are present`() {
+        assertThat(chessBoard.getPiecesOnBoard()).isEmpty()
+    }
+
+    @Test
+    fun `given different board sizes, when creating chessboards, then correct sizes are set`() {
+        val smallBoard = ChessBoard(4)
+        val largeBoard = ChessBoard(12)
+
+        assertThat(smallBoard.size).isEqualTo(4)
+        assertThat(largeBoard.size).isEqualTo(12)
+    }
+
+    // Position Access Tests
+
+    @Test
+    fun `given valid position, when accessing position, then returns StateFlow with empty spot`() =
+        runTest {
+            val position = BoardPosition.of(3, 4)
+            val stateFlow = chessBoard[position]
+
+            assertThat(stateFlow).isNotNull
+            assertThat(stateFlow.first()).isEqualTo(Spot.EmptySpot)
+        }
+
+    @Test
+    fun `given negative coordinates, when accessing position, then throws IllegalArgumentException`() {
+        val invalidPosition = BoardPosition.of(-1, 3)
+
+        assertThatThrownBy { chessBoard[invalidPosition] }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("out of bounds")
+    }
+
+    @Test
+    fun `given coordinates too large, when accessing position, then throws IllegalArgumentException`() {
+        val invalidPosition = BoardPosition.of(8, 3) // Board is 0-7
+
+        assertThatThrownBy { chessBoard[invalidPosition] }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("out of bounds")
+    }
+
+    @Test
+    fun `given chessboard, when accessing all valid positions, then no exceptions are thrown`() =
+        runTest {
+            for (x in 0 until chessBoard.size) {
+                for (y in 0 until chessBoard.size) {
+                    val position = BoardPosition.of(x, y)
+                    // Should not throw exception
+                    val stateFlow = chessBoard[position]
+                    assertThat(stateFlow.first()).isEqualTo(Spot.EmptySpot)
+                }
+            }
+        }
+
+    // Piece Placement Tests
+
+    @Test
+    fun `given empty spot, when placing piece, then piece is placed successfully`() =
+        runTest {
+            val position = BoardPosition.of(4, 4)
+            val pieceSpot = Spot.PieceSpot(mockPiece)
+
+            chessBoard.setSpot(pieceSpot, position)
+
+            val retrievedSpot = chessBoard[position].first()
+            assertThat(retrievedSpot).isEqualTo(pieceSpot)
+        }
+
+    @Test
+    fun `given empty spot, when placing piece, then pieces tracking is updated`() {
+        val position = BoardPosition.of(2, 6)
+        val pieceSpot = Spot.PieceSpot(mockPiece)
+
+        chessBoard.setSpot(pieceSpot, position)
+
+        val piecesOnBoard = chessBoard.getPiecesOnBoard()
+        assertThat(piecesOnBoard).hasSize(1)
+        assertThat(piecesOnBoard[position]).isEqualTo(pieceSpot)
+    }
+
+    @Test
+    fun `given existing piece, when placing new piece, then piece is replaced`() =
+        runTest {
+            val position = BoardPosition.of(1, 1)
+            val originalPiece = Spot.PieceSpot(mockPiece)
+            val newMockPiece =
+                mock<Piece> {
+                    on { pieceColor }.thenReturn(PieceColor.BLACK)
+                }
+            val newPiece = Spot.PieceSpot(newMockPiece)
+
+            // Place original piece
+            chessBoard.setSpot(originalPiece, position)
+            assertThat(chessBoard[position].first()).isEqualTo(originalPiece)
+
+            // Replace with new piece
+            chessBoard.setSpot(newPiece, position)
+            val retrievedSpot = chessBoard[position].first()
+            assertThat(retrievedSpot).isEqualTo(newPiece)
+
+            // Verify only new piece is tracked
+            val piecesOnBoard = chessBoard.getPiecesOnBoard()
+            assertThat(piecesOnBoard).hasSize(1)
+            assertThat(piecesOnBoard[position]).isEqualTo(newPiece)
+        }
+
+    @Test
+    fun `given piece on board, when setting empty spot, then piece is removed`() =
+        runTest {
+            val position = BoardPosition.of(7, 0)
+            val pieceSpot = Spot.PieceSpot(mockPiece)
+
+            // Place piece
+            chessBoard.setSpot(pieceSpot, position)
+            assertThat(chessBoard.getPiecesOnBoard()).hasSize(1)
+
+            // Remove piece by setting empty spot
+            chessBoard.setSpot(Spot.EmptySpot, position)
+
+            assertThat(chessBoard[position].first()).isEqualTo(Spot.EmptySpot)
+            assertThat(chessBoard.getPiecesOnBoard()).isEmpty()
+        }
+
+    @Test
+    fun `given out of bounds position, when placing piece, then throws IllegalArgumentException`() {
+        val invalidPosition = BoardPosition.of(10, 5)
+        val pieceSpot = Spot.PieceSpot(mockPiece)
+
+        assertThatThrownBy { chessBoard.setSpot(pieceSpot, invalidPosition) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("out of bounds")
+    }
+
+    // Piece Tracking Tests
+
+    @Test
+    fun `given multiple pieces, when placing them on board, then all pieces are tracked correctly`() {
+        val positions =
+            listOf(
+                BoardPosition.of(0, 0),
+                BoardPosition.of(2, 3),
+                BoardPosition.of(7, 7),
+                BoardPosition.of(4, 1),
+            )
+        val pieces = positions.map { Spot.PieceSpot(mockPiece) }
+
+        // Place pieces
+        positions.zip(pieces).forEach { (position, piece) ->
+            chessBoard.setSpot(piece, position)
+        }
+
+        val piecesOnBoard = chessBoard.getPiecesOnBoard()
+        assertThat(piecesOnBoard).hasSize(4)
+        positions.forEach { position ->
+            assertThat(piecesOnBoard).containsKey(position)
+        }
+    }
+
+    @Test
+    fun `given empty board, when getting pieces on board, then returns empty map`() {
+        assertThat(chessBoard.getPiecesOnBoard()).isEmpty()
+    }
+
+    @Test
+    fun `given empty spot, when setting empty spot, then no pieces are tracked`() {
+        val position = BoardPosition.of(3, 3)
+        chessBoard.setSpot(Spot.EmptySpot, position)
+
+        assertThat(chessBoard.getPiecesOnBoard()).isEmpty()
+    }
+
+    // Board Clearing Tests
+
+    @Test
+    fun `given board with pieces, when clearing board, then all pieces are removed`() =
+        runTest {
+            // Place multiple pieces
+            val positions =
+                listOf(
+                    BoardPosition.of(1, 1),
+                    BoardPosition.of(3, 5),
+                    BoardPosition.of(6, 2),
+                )
+            positions.forEach { position ->
+                chessBoard.setSpot(Spot.PieceSpot(mockPiece), position)
+            }
+
+            // Verify pieces are placed
+            assertThat(chessBoard.getPiecesOnBoard()).hasSize(3)
+
+            // Clear board
+            chessBoard.clear()
+
+            // Verify all positions are empty
+            for (x in 0 until chessBoard.size) {
+                for (y in 0 until chessBoard.size) {
+                    val position = BoardPosition.of(x, y)
+                    assertThat(chessBoard[position].first()).isEqualTo(Spot.EmptySpot)
+                }
+            }
+
+            // Verify pieces tracking is cleared
+            assertThat(chessBoard.getPiecesOnBoard()).isEmpty()
+        }
+
+    @Test
+    fun `given empty board, when clearing board, then board remains empty without exceptions`() =
+        runTest {
+            chessBoard.clear()
+
+            // Should still be empty and not throw exception
+            assertThat(chessBoard.getPiecesOnBoard()).isEmpty()
+            val position = BoardPosition.of(0, 0)
+            assertThat(chessBoard[position].first()).isEqualTo(Spot.EmptySpot)
+        }
+
+    // StateFlow Reactivity Tests
+
+    @Test
+    fun `given position StateFlow, when changing spot, then StateFlow emits new state`() =
+        runTest {
+            val position = BoardPosition.of(5, 3)
+            val stateFlow = chessBoard[position]
+            val pieceSpot = Spot.PieceSpot(mockPiece)
+
+            // Initial state should be empty
+            assertThat(stateFlow.first()).isEqualTo(Spot.EmptySpot)
+
+            // Place piece and verify state change
+            chessBoard.setSpot(pieceSpot, position)
+            assertThat(stateFlow.first()).isEqualTo(pieceSpot)
+
+            // Remove piece and verify state change
+            chessBoard.setSpot(Spot.EmptySpot, position)
+            assertThat(stateFlow.first()).isEqualTo(Spot.EmptySpot)
+        }
+
+    @Test
+    fun `given different positions, when changing one position, then other positions remain unchanged`() =
+        runTest {
+            val position1 = BoardPosition.of(0, 0)
+            val position2 = BoardPosition.of(7, 7)
+            val stateFlow1 = chessBoard[position1]
+            val stateFlow2 = chessBoard[position2]
+
+            // Place piece at position1 only
+            chessBoard.setSpot(Spot.PieceSpot(mockPiece), position1)
+
+            // Position1 should have piece, position2 should remain empty
+            assertThat(stateFlow1.first()).isInstanceOf(Spot.PieceSpot::class.java)
+            assertThat(stateFlow2.first()).isEqualTo(Spot.EmptySpot)
+        }
+
+    // Edge Cases Tests
+
+    @Test
+    fun `given minimum board size, when creating board, then 1x1 board works correctly`() =
+        runTest {
+            val tinyBoard = ChessBoard(1)
+            val position = BoardPosition.of(0, 0)
+
+            assertThat(tinyBoard.size).isEqualTo(1)
+            assertThat(tinyBoard[position].first()).isEqualTo(Spot.EmptySpot)
+
+            tinyBoard.setSpot(Spot.PieceSpot(mockPiece), position)
+            assertThat(tinyBoard.getPiecesOnBoard()).hasSize(1)
+        }
+
+    @Test
+    fun `given large board size, when creating board, then large board is handled correctly`() {
+        val largeBoard = ChessBoard(100)
+        assertThat(largeBoard.size).isEqualTo(100)
+        assertThat(largeBoard.getPiecesOnBoard()).isEmpty()
+    }
+
+    @Test
+    fun `given boundary positions, when accessing them, then all corner positions work correctly`() =
+        runTest {
+            val boundaryPositions =
+                listOf(
+                    BoardPosition.of(0, 0), // Top-left corner
+                    BoardPosition.of(0, 7), // Top-right corner
+                    BoardPosition.of(7, 0), // Bottom-left corner
+                    BoardPosition.of(7, 7), // Bottom-right corner
+                )
+
+            boundaryPositions.forEach { position ->
+                // Should be accessible without exception
+                val stateFlow = chessBoard[position]
+                assertThat(stateFlow.first()).isEqualTo(Spot.EmptySpot)
+
+                // Should be able to place and remove pieces
+                chessBoard.setSpot(Spot.PieceSpot(mockPiece), position)
+                assertThat(stateFlow.first()).isInstanceOf(Spot.PieceSpot::class.java)
+            }
+        }
+}

--- a/app/src/test/java/com/nqueens/game/core/board/domain/pieces/QueenPieceTest.kt
+++ b/app/src/test/java/com/nqueens/game/core/board/domain/pieces/QueenPieceTest.kt
@@ -1,0 +1,513 @@
+package com.nqueens.game.core.board.domain.pieces
+
+import com.nqueens.game.BaseUnitTest
+import com.nqueens.game.core.board.domain.BoardPosition
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class QueenPieceTest : BaseUnitTest() {
+    private val queen = QueenPiece(PieceColor.WHITE)
+    private val board4x4 = 4
+    private val board8x8 = 8
+    private val board9x9 = 9
+
+    @Test
+    fun `given an empty 4x4 chess board, when putting a queen on A1, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 0, y = 0)
+
+        val result = queen.getPossibleMoves(board4x4, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                BoardPosition.of(1, 1),
+                BoardPosition.of(2, 2),
+                BoardPosition.of(3, 3),
+                BoardPosition.of(0, 1),
+                BoardPosition.of(0, 2),
+                BoardPosition.of(0, 3),
+                BoardPosition.of(1, 0),
+                BoardPosition.of(2, 0),
+                BoardPosition.of(3, 0),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 4x4 chess board, when putting a queen on C3, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 2, y = 2)
+
+        val result = queen.getPossibleMoves(board4x4, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(0, 2),
+                BoardPosition.of(1, 2),
+                BoardPosition.of(3, 2),
+                // Vertical
+                BoardPosition.of(2, 0),
+                BoardPosition.of(2, 1),
+                BoardPosition.of(2, 3),
+                // Diagonal up-right
+                BoardPosition.of(3, 3),
+                // Diagonal down-left
+                BoardPosition.of(1, 1),
+                BoardPosition.of(0, 0),
+                // Diagonal down-right
+                BoardPosition.of(3, 1),
+                // Diagonal up-left
+                BoardPosition.of(1, 3),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 4x4 chess board, when putting a queen on D4, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 3, y = 3)
+
+        val result = queen.getPossibleMoves(board4x4, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(0, 3),
+                BoardPosition.of(1, 3),
+                BoardPosition.of(2, 3),
+                // Vertical
+                BoardPosition.of(3, 0),
+                BoardPosition.of(3, 1),
+                BoardPosition.of(3, 2),
+                // Diagonal down-left
+                BoardPosition.of(2, 2),
+                BoardPosition.of(1, 1),
+                BoardPosition.of(0, 0),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 8x8 chess board, when putting a queen on D4, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 3, y = 3)
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(0, 3),
+                BoardPosition.of(1, 3),
+                BoardPosition.of(2, 3),
+                BoardPosition.of(4, 3),
+                BoardPosition.of(5, 3),
+                BoardPosition.of(6, 3),
+                BoardPosition.of(7, 3),
+                // Vertical
+                BoardPosition.of(3, 0),
+                BoardPosition.of(3, 1),
+                BoardPosition.of(3, 2),
+                BoardPosition.of(3, 4),
+                BoardPosition.of(3, 5),
+                BoardPosition.of(3, 6),
+                BoardPosition.of(3, 7),
+                // Diagonal up-right
+                BoardPosition.of(4, 4),
+                BoardPosition.of(5, 5),
+                BoardPosition.of(6, 6),
+                BoardPosition.of(7, 7),
+                // Diagonal down-left
+                BoardPosition.of(2, 2),
+                BoardPosition.of(1, 1),
+                BoardPosition.of(0, 0),
+                // Diagonal up-left
+                BoardPosition.of(2, 4),
+                BoardPosition.of(1, 5),
+                BoardPosition.of(0, 6),
+                // Diagonal down-right
+                BoardPosition.of(4, 2),
+                BoardPosition.of(5, 1),
+                BoardPosition.of(6, 0),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 8x8 chess board, when putting a queen on A8, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 0, y = 7)
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(1, 7),
+                BoardPosition.of(2, 7),
+                BoardPosition.of(3, 7),
+                BoardPosition.of(4, 7),
+                BoardPosition.of(5, 7),
+                BoardPosition.of(6, 7),
+                BoardPosition.of(7, 7),
+                // Vertical
+                BoardPosition.of(0, 0),
+                BoardPosition.of(0, 1),
+                BoardPosition.of(0, 2),
+                BoardPosition.of(0, 3),
+                BoardPosition.of(0, 4),
+                BoardPosition.of(0, 5),
+                BoardPosition.of(0, 6),
+                // Diagonal down-right
+                BoardPosition.of(1, 6),
+                BoardPosition.of(2, 5),
+                BoardPosition.of(3, 4),
+                BoardPosition.of(4, 3),
+                BoardPosition.of(5, 2),
+                BoardPosition.of(6, 1),
+                BoardPosition.of(7, 0),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 8x8 chess board, when putting a queen on E5, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 4, y = 4)
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(0, 4),
+                BoardPosition.of(1, 4),
+                BoardPosition.of(2, 4),
+                BoardPosition.of(3, 4),
+                BoardPosition.of(5, 4),
+                BoardPosition.of(6, 4),
+                BoardPosition.of(7, 4),
+                // Vertical
+                BoardPosition.of(4, 0),
+                BoardPosition.of(4, 1),
+                BoardPosition.of(4, 2),
+                BoardPosition.of(4, 3),
+                BoardPosition.of(4, 5),
+                BoardPosition.of(4, 6),
+                BoardPosition.of(4, 7),
+                // Diagonal up-right
+                BoardPosition.of(5, 5),
+                BoardPosition.of(6, 6),
+                BoardPosition.of(7, 7),
+                // Diagonal down-left
+                BoardPosition.of(3, 3),
+                BoardPosition.of(2, 2),
+                BoardPosition.of(1, 1),
+                BoardPosition.of(0, 0),
+                // Diagonal up-left
+                BoardPosition.of(3, 5),
+                BoardPosition.of(2, 6),
+                BoardPosition.of(1, 7),
+                // Diagonal down-right
+                BoardPosition.of(5, 3),
+                BoardPosition.of(6, 2),
+                BoardPosition.of(7, 1),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 9x9 chess board, when putting a queen on E5, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 4, y = 4)
+
+        val result = queen.getPossibleMoves(board9x9, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(0, 4),
+                BoardPosition.of(1, 4),
+                BoardPosition.of(2, 4),
+                BoardPosition.of(3, 4),
+                BoardPosition.of(5, 4),
+                BoardPosition.of(6, 4),
+                BoardPosition.of(7, 4),
+                BoardPosition.of(8, 4),
+                // Vertical
+                BoardPosition.of(4, 0),
+                BoardPosition.of(4, 1),
+                BoardPosition.of(4, 2),
+                BoardPosition.of(4, 3),
+                BoardPosition.of(4, 5),
+                BoardPosition.of(4, 6),
+                BoardPosition.of(4, 7),
+                BoardPosition.of(4, 8),
+                // Diagonal up-right
+                BoardPosition.of(5, 5),
+                BoardPosition.of(6, 6),
+                BoardPosition.of(7, 7),
+                BoardPosition.of(8, 8),
+                // Diagonal down-left
+                BoardPosition.of(3, 3),
+                BoardPosition.of(2, 2),
+                BoardPosition.of(1, 1),
+                BoardPosition.of(0, 0),
+                // Diagonal up-left
+                BoardPosition.of(3, 5),
+                BoardPosition.of(2, 6),
+                BoardPosition.of(1, 7),
+                BoardPosition.of(0, 8),
+                // Diagonal down-right
+                BoardPosition.of(5, 3),
+                BoardPosition.of(6, 2),
+                BoardPosition.of(7, 1),
+                BoardPosition.of(8, 0),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 9x9 chess board, when putting a queen on A1, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 0, y = 0)
+
+        val result = queen.getPossibleMoves(board9x9, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(1, 0),
+                BoardPosition.of(2, 0),
+                BoardPosition.of(3, 0),
+                BoardPosition.of(4, 0),
+                BoardPosition.of(5, 0),
+                BoardPosition.of(6, 0),
+                BoardPosition.of(7, 0),
+                BoardPosition.of(8, 0),
+                // Vertical
+                BoardPosition.of(0, 1),
+                BoardPosition.of(0, 2),
+                BoardPosition.of(0, 3),
+                BoardPosition.of(0, 4),
+                BoardPosition.of(0, 5),
+                BoardPosition.of(0, 6),
+                BoardPosition.of(0, 7),
+                BoardPosition.of(0, 8),
+                // Diagonal up-right
+                BoardPosition.of(1, 1),
+                BoardPosition.of(2, 2),
+                BoardPosition.of(3, 3),
+                BoardPosition.of(4, 4),
+                BoardPosition.of(5, 5),
+                BoardPosition.of(6, 6),
+                BoardPosition.of(7, 7),
+                BoardPosition.of(8, 8),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given an empty 9x9 chess board, when putting a queen on I9, the possible moves are available`() {
+        val initialPosition = BoardPosition.of(x = 8, y = 8)
+
+        val result = queen.getPossibleMoves(board9x9, initialPosition, emptyMap())
+
+        val expected =
+            setOf(
+                // Horizontal
+                BoardPosition.of(0, 8),
+                BoardPosition.of(1, 8),
+                BoardPosition.of(2, 8),
+                BoardPosition.of(3, 8),
+                BoardPosition.of(4, 8),
+                BoardPosition.of(5, 8),
+                BoardPosition.of(6, 8),
+                BoardPosition.of(7, 8),
+                // Vertical
+                BoardPosition.of(8, 0),
+                BoardPosition.of(8, 1),
+                BoardPosition.of(8, 2),
+                BoardPosition.of(8, 3),
+                BoardPosition.of(8, 4),
+                BoardPosition.of(8, 5),
+                BoardPosition.of(8, 6),
+                BoardPosition.of(8, 7),
+                // Diagonal down-left
+                BoardPosition.of(7, 7),
+                BoardPosition.of(6, 6),
+                BoardPosition.of(5, 5),
+                BoardPosition.of(4, 4),
+                BoardPosition.of(3, 3),
+                BoardPosition.of(2, 2),
+                BoardPosition.of(1, 1),
+                BoardPosition.of(0, 0),
+            )
+
+        assertThat(expected).isEqualTo(result.toSet())
+    }
+
+    @Test
+    fun `given a board with enemy pieces, queen can capture but not move beyond them`() {
+        val initialPosition = BoardPosition.of(x = 4, y = 4) // Queen at E5
+        val enemyQueen = QueenPiece(PieceColor.BLACK)
+
+        val currentPieces =
+            mapOf(
+                BoardPosition.of(4, 6) to enemyQueen,
+                BoardPosition.of(2, 4) to enemyQueen,
+                BoardPosition.of(6, 2) to enemyQueen,
+            )
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, currentPieces)
+
+        // Queen should be able to capture enemy pieces
+        assertThat(result).contains(
+            BoardPosition.of(4, 6), // Enemy above
+            BoardPosition.of(2, 4), // Enemy to the left
+            BoardPosition.of(6, 2), // Enemy on down-right diagonal
+        )
+
+        // Queen shouldn't be able to move beyond enemy pieces
+        assertThat(result).doesNotContain(
+            BoardPosition.of(4, 7), // Beyond enemy above
+            BoardPosition.of(1, 4), // Beyond enemy to the left
+            BoardPosition.of(7, 1), // Beyond enemy on down-right diagonal
+        )
+    }
+
+    @Test
+    fun `given a board with friendly pieces, queen cannot move to or beyond them`() {
+        val initialPosition = BoardPosition.of(x = 4, y = 4) // Queen at E5
+        val friendlyQueen = QueenPiece(PieceColor.WHITE)
+
+        val currentPieces =
+            mapOf(
+                BoardPosition.of(4, 2) to friendlyQueen,
+                BoardPosition.of(7, 4) to friendlyQueen,
+                BoardPosition.of(2, 6) to friendlyQueen,
+            )
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, currentPieces)
+
+        // Queen shouldn't be able to move to spaces with friendly pieces
+        assertThat(result).doesNotContain(
+            BoardPosition.of(4, 2), // Friendly below
+            BoardPosition.of(7, 4), // Friendly to the right
+            BoardPosition.of(2, 6), // Friendly on up-left diagonal
+        )
+
+        // Queen shouldn't be able to move beyond friendly pieces
+        assertThat(result).doesNotContain(
+            BoardPosition.of(4, 1), // Beyond friendly below
+            BoardPosition.of(4, 0), // Beyond friendly below
+            BoardPosition.of(8, 4), // Beyond friendly to the right (would be out of bounds anyway)
+            BoardPosition.of(1, 7), // Beyond friendly on up-left diagonal
+            BoardPosition.of(0, 8), // Beyond friendly on up-left diagonal
+        )
+    }
+
+    @Test
+    fun `given a complex board with mixed pieces, queen moves correctly`() {
+        val initialPosition = BoardPosition.of(x = 3, y = 3) // Queen at D4
+
+        // Setup pieces on the board
+        val currentPieces =
+            mapOf(
+                // Friendly pieces
+                BoardPosition.of(3, 1) to QueenPiece(PieceColor.WHITE), // D2 - blocks don
+                BoardPosition.of(5, 5) to QueenPiece(PieceColor.WHITE), // F6 - blocks up-right diagonl
+                // Enemy pieces
+                BoardPosition.of(0, 3) to QueenPiece(PieceColor.BLACK), // A4 - can capture let
+                BoardPosition.of(3, 6) to QueenPiece(PieceColor.BLACK), // D7 - can capture p
+                BoardPosition.of(1, 5) to QueenPiece(PieceColor.BLACK), // B6 - can capture up-left diagonl
+            )
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, currentPieces)
+
+        // Places queen should be able to move (no pieces blocking)
+        assertThat(result).contains(
+            // Right horizontal (unblocked)
+            BoardPosition.of(4, 3),
+            BoardPosition.of(5, 3),
+            BoardPosition.of(6, 3),
+            BoardPosition.of(7, 3),
+            // Left horizontal (until enemy piece)
+            BoardPosition.of(2, 3),
+            BoardPosition.of(1, 3),
+            BoardPosition.of(0, 3), // Can capture at A4
+            // Up vertical (until enemy piece)
+            BoardPosition.of(3, 4),
+            BoardPosition.of(3, 5),
+            BoardPosition.of(3, 6), // Can capture at D7
+            // Down vertical (until friendly piece)
+            BoardPosition.of(3, 2), // Can move until D2
+            // Down-left diagonal (unblocked)
+            BoardPosition.of(2, 2),
+            BoardPosition.of(1, 1),
+            BoardPosition.of(0, 0),
+            // Down-right diagonal (unblocked)
+            BoardPosition.of(4, 2),
+            BoardPosition.of(5, 1),
+            BoardPosition.of(6, 0),
+            // Up-left diagonal (until enemy piece)
+            BoardPosition.of(2, 4),
+            BoardPosition.of(1, 5), // Can capture at B6
+            // Up-right diagonal (until friendly piece)
+            BoardPosition.of(4, 4), // Can move until F6
+        )
+
+        // Places queen shouldn't be able to move (blocked by pieces)
+        assertThat(result).doesNotContain(
+            // Blocked by friendly pieces
+            BoardPosition.of(3, 1), // Friendly at D2
+            BoardPosition.of(3, 0), // Beyond friendly at D2
+            BoardPosition.of(5, 5), // Friendly at F6
+            BoardPosition.of(6, 6), // Beyond friendly at F6
+            BoardPosition.of(7, 7), // Beyond friendly at F6
+            // Beyond enemy pieces
+            BoardPosition.of(3, 7), // Beyond enemy at D7
+            BoardPosition.of(0, 6), // Beyond enemy at B6
+            BoardPosition.of(-1, 3), // Beyond enemy at A4 (would be out of bounds anyway)
+        )
+    }
+
+    @Test
+    fun `given a board with pieces surrounding queen, queen can only capture enemy pieces`() {
+        val initialPosition = BoardPosition.of(x = 4, y = 4) // Queen at E5
+
+        // Setup a mix of friendly and enemy pieces surrounding the queen
+        val currentPieces =
+            mapOf(
+                // Friendly pieces (4 directions)
+                BoardPosition.of(3, 3) to QueenPiece(PieceColor.WHITE), // Down-let
+                BoardPosition.of(4, 3) to QueenPiece(PieceColor.WHITE), // Don
+                BoardPosition.of(5, 5) to QueenPiece(PieceColor.WHITE), // Up-rigt
+                BoardPosition.of(3, 5) to QueenPiece(PieceColor.WHITE), // Up-let
+                // Enemy pieces (4 directions)
+                BoardPosition.of(5, 3) to QueenPiece(PieceColor.BLACK), // Down-rigt
+                BoardPosition.of(5, 4) to QueenPiece(PieceColor.BLACK), // Rigt
+                BoardPosition.of(4, 5) to QueenPiece(PieceColor.BLACK), // p
+                BoardPosition.of(3, 4) to QueenPiece(PieceColor.BLACK), // Let
+            )
+
+        val result = queen.getPossibleMoves(board8x8, initialPosition, currentPieces)
+
+        // Queen should only be able to capture the 4 enemy pieces
+        assertThat(result).containsExactlyInAnyOrder(
+            BoardPosition.of(5, 3), // Enemy down-right
+            BoardPosition.of(5, 4), // Enemy right
+            BoardPosition.of(4, 5), // Enemy up
+            BoardPosition.of(3, 4), // Enemy left
+        )
+
+        // Should not contain friendly pieces or any spaces beyond pieces
+        assertThat(result).doesNotContain(
+            BoardPosition.of(3, 3), // Friendly down-left
+            BoardPosition.of(4, 3), // Friendly down
+            BoardPosition.of(5, 5), // Friendly up-right
+            BoardPosition.of(3, 5), // Friendly up-left
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces a foundational implementation for an N-Queens puzzle and chess-like board game system. The changes span across domain logic, UI components, and game mechanics, establishing the core structure and behavior for the game. Key additions include reactive board state management, piece movement logic, and a composable UI component for rendering board cells.

### Domain Logic Enhancements:
* **Board Interface**: Added `Board` interface to define reactive state management for board positions using `StateFlow`. Includes methods for setting spots, retrieving pieces, and clearing the board. (`Board.kt`)
* **BoardPosition Class**: Implemented `BoardPosition` with a Flyweight pattern for memory efficiency, ensuring shared instances for identical coordinates. (`BoardPosition.kt`)
* **Spot Interface**: Introduced `Spot` sealed interface with `EmptySpot` and `PieceSpot` to represent board states. (`Spot.kt`)

### Game Mechanics:
* **ChessBoard Implementation**: Created a concrete implementation of `Board` with reactive state updates, bounds checking, and efficient piece tracking. (`ChessBoard.kt`)
* **Piece Interface and Queen Implementation**: Added `Piece` interface for defining movement rules and implemented `QueenPiece` with logic for calculating possible moves. (`Piece.kt`, `QueenPiece.kt`) [[1]](diffhunk://#diff-60effc11ece1fca1f04d27dd64324442bc031d78e42c1a8e97279250083f9d4bR1-R49) [[2]](diffhunk://#diff-8e1307a010415ec452d5069d996d6ac573d8a1cb321297d6ebdfc1da8e1e88f0R1-R177)

### UI Components:
* **BoardCell Composable**: Developed a UI component for rendering individual board cells with dynamic coloring, piece display, and interaction handling. (`BoardCell.kt`)
* **BoardView Composable**: Developed a UI component for rendering chess boards.  